### PR TITLE
fixes for build_docs GHA workflow

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -35,6 +35,7 @@ jobs:
           python -m pip install .[dev]
 
       - name: Build Docs
+        shell: bash -l {0}
         run: |
           cd docs
           make html


### PR DESCRIPTION
This PR is simply trying to fix some issues with the build_docs GitHub action workflow. Currently, the `Build Docs` step is failing with the error `sphinx-build: not found`. This is likely due to the mamba environment not being active for that step in the workflow. To fix this issue, I added the `shell` specification to use `bash`, which should ensure that mamba env is activate when building sphinx docs.