### PR TITLE
Fixed small error from missing version file.

### DIFF
--- a/reVeal/__init__.py
+++ b/reVeal/__init__.py
@@ -1,10 +1,9 @@
-"""reVeal"""
-
+"""The reV Extension for Analyzing Large Loads."""
 from pathlib import Path
 
 import pyproj
 
-from reVeal._version import __version__
+from reVeal.version import __version__
 
 # stop to_crs() bugs
 pyproj.network.set_network_enabled(active=False)

--- a/reVeal/version.py
+++ b/reVeal/version.py
@@ -1,0 +1,3 @@
+"""reVeal Version number."""
+
+__version__ = "0.2.2"


### PR DESCRIPTION
We were just missing the _version.py file called in init. I also spelled out the full package acronym in the init file like we do in reV:

```python
In [1]: import reVeal
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[1], line 1
----> 1 import reVeal

File /kfs3/conda/twillia2/gitrepos/reVeal/reVeal/__init__.py:7
      3 from pathlib import Path
      5 import pyproj
----> 7 from reVeal._version import __version__
      9 # stop to_crs() bugs
     10 pyproj.network.set_network_enabled(active=False)

ModuleNotFoundError: No module named 'reVeal._version'
```