### PR TITLE
Add learn-weights CLI step with PU learning and Optuna tuning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
     - pyogrio>=0.12.1,<0.13
     - pyarrow>=22.0.0,<23
     - proj-data>=1.24,<2
+    - scikit-learn>=1.4.0,<2
     - scipy>=1.14.0,<2
     - tqdm>=4.67.1,<5
     - exactextract>=0.2.2,<1

--- a/environment.yml
+++ b/environment.yml
@@ -8,11 +8,14 @@ dependencies:
     - geopandas>=1.1.1,<2
     - rasterio>=1.4.4,<2
     - gdal>=3.12.1,<4
+    - joblib>=1.4.0,<2
     - pyogrio>=0.12.1,<0.13
     - pyarrow>=22.0.0,<23
     - proj-data>=1.24,<2
+    - scipy>=1.14.0,<2
     - tqdm>=4.67.1,<5
     - exactextract>=0.2.2,<1
+    - optuna>=4.0.0,<5
     - pydantic>=2.12.5,<3
     - libpysal>=4.13.0,<5
     - pip>=25.2

--- a/pixi.lock
+++ b/pixi.lock
@@ -299,25 +299,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/63/2ab26e4209773223159b83aa32721b4021ffb08102f8ac7d689c943fded1/multidict-6.7.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7c/a3/8ffe10a49652bfd769348c6eca577463c2b3938baab5e62f3896fc5da0b7/pyjson5-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -615,25 +621,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/d4/438efabdf74e30aeceb890c3290bbaa449780583b1270b00661126b8aae4/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/ee/f524093232007cd7a75c1d132df70f235cfd590a7c9eaccd7ff422ef4ae8/multidict-6.7.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/06/e4/b751cdf839c011a9714a783f120e6a86b7494eb70044d7d81a25a5cd295f/psutil-7.2.1-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/97/e104682432b02f1458de22478d2b62caa607426e8284bec4680a3537cadd/pyjson5-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -917,8 +929,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
@@ -926,16 +940,19 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/e2/64bb41266427af6642b6b128e8774ed84c11b80a90702c13ac0a86bb10cc/multidict-6.7.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/2c/78e4a789306a92ade5000da4f5de3255202c534acdadc3aac7b5458fadef/psutil-7.2.1-cp36-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/39/1b/9cd7acea4c0e5a4ed44a79b99fc7e3a50b69639ea9f926efc35d660bef04/pyjson5-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -1205,25 +1222,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/56/982704adea7d3b16614fc5936014e9af85c0e34b58f9046655817f04306e/aiohttp-3.13.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/16/7ed27b680791b939de138f906d5cf2b4657b0d45ca6f5dd6236fdddafb1a/multidict-6.7.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/2a/a758b47de253636e1b8aef181c0b4f4f204bf0dd964914fb2af90a95b49b/propcache-0.4.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/52/8c/1bb60288c4d480a0b51e376a17d6c4d932dc8420989d1db440e3b284aad5/pyjson5-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -1523,25 +1546,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/63/2ab26e4209773223159b83aa32721b4021ffb08102f8ac7d689c943fded1/multidict-6.7.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7c/a3/8ffe10a49652bfd769348c6eca577463c2b3938baab5e62f3896fc5da0b7/pyjson5-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -1832,25 +1861,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/d4/438efabdf74e30aeceb890c3290bbaa449780583b1270b00661126b8aae4/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/ee/f524093232007cd7a75c1d132df70f235cfd590a7c9eaccd7ff422ef4ae8/multidict-6.7.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/06/e4/b751cdf839c011a9714a783f120e6a86b7494eb70044d7d81a25a5cd295f/psutil-7.2.1-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/97/e104682432b02f1458de22478d2b62caa607426e8284bec4680a3537cadd/pyjson5-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -2127,8 +2162,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
@@ -2136,16 +2173,19 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/e2/64bb41266427af6642b6b128e8774ed84c11b80a90702c13ac0a86bb10cc/multidict-6.7.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/2c/78e4a789306a92ade5000da4f5de3255202c534acdadc3aac7b5458fadef/psutil-7.2.1-cp36-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/39/1b/9cd7acea4c0e5a4ed44a79b99fc7e3a50b69639ea9f926efc35d660bef04/pyjson5-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -2408,25 +2448,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/56/982704adea7d3b16614fc5936014e9af85c0e34b58f9046655817f04306e/aiohttp-3.13.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/16/7ed27b680791b939de138f906d5cf2b4657b0d45ca6f5dd6236fdddafb1a/multidict-6.7.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/2a/a758b47de253636e1b8aef181c0b4f4f204bf0dd964914fb2af90a95b49b/propcache-0.4.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/52/8c/1bb60288c4d480a0b51e376a17d6c4d932dc8420989d1db440e3b284aad5/pyjson5-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -2804,6 +2850,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
@@ -2812,12 +2859,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/3e/e27078370414ef35fafad2c06d182110073daaeb5d3bf734b0b1eeefe452/debugpy-1.8.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
@@ -2839,6 +2888,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/63/2ab26e4209773223159b83aa32721b4021ffb08102f8ac7d689c943fded1/multidict-6.7.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
@@ -2846,6 +2896,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/32/55/b754cd51c6011d90ef03e3f06136f1ebd44658b9529dbcf0c15fc0d6a0b7/notebook-7.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/ea/74c89d786cf3403bfbf8fb70142fdf501af9517d0bb8c1acce3ee5ab613e/pipreqs-0.4.13-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl
@@ -2863,6 +2914,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/5e/d3a6fdf61f6373e53bfb45d6819a72dfef741bc8a9ff31c64496688e7c39/ruff_lsp-0.0.62-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
@@ -3235,6 +3287,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/d4/438efabdf74e30aeceb890c3290bbaa449780583b1270b00661126b8aae4/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
@@ -3243,12 +3296,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/3e/e27078370414ef35fafad2c06d182110073daaeb5d3bf734b0b1eeefe452/debugpy-1.8.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
@@ -3270,6 +3325,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/ee/f524093232007cd7a75c1d132df70f235cfd590a7c9eaccd7ff422ef4ae8/multidict-6.7.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
@@ -3277,6 +3333,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/32/55/b754cd51c6011d90ef03e3f06136f1ebd44658b9529dbcf0c15fc0d6a0b7/notebook-7.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/ea/74c89d786cf3403bfbf8fb70142fdf501af9517d0bb8c1acce3ee5ab613e/pipreqs-0.4.13-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl
@@ -3294,6 +3351,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/5e/d3a6fdf61f6373e53bfb45d6819a72dfef741bc8a9ff31c64496688e7c39/ruff_lsp-0.0.62-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
@@ -3652,6 +3710,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
@@ -3661,6 +3720,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/3e/e27078370414ef35fafad2c06d182110073daaeb5d3bf734b0b1eeefe452/debugpy-1.8.19-py2.py3-none-any.whl
@@ -3688,6 +3748,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/e2/64bb41266427af6642b6b128e8774ed84c11b80a90702c13ac0a86bb10cc/multidict-6.7.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
@@ -3695,6 +3756,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/32/55/b754cd51c6011d90ef03e3f06136f1ebd44658b9529dbcf0c15fc0d6a0b7/notebook-7.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/ea/74c89d786cf3403bfbf8fb70142fdf501af9517d0bb8c1acce3ee5ab613e/pipreqs-0.4.13-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl
@@ -3712,6 +3774,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/5e/d3a6fdf61f6373e53bfb45d6819a72dfef741bc8a9ff31c64496688e7c39/ruff_lsp-0.0.62-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
@@ -4055,6 +4118,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/56/982704adea7d3b16614fc5936014e9af85c0e34b58f9046655817f04306e/aiohttp-3.13.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl
@@ -4063,12 +4127,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/b8/bfdc30b6e94f1eff09f2dc9cc1f9cd1c6cde3d996bcbd36ce2d9a4956e99/debugpy-1.8.19-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
@@ -4090,6 +4156,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/16/7ed27b680791b939de138f906d5cf2b4657b0d45ca6f5dd6236fdddafb1a/multidict-6.7.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
@@ -4097,6 +4164,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/32/55/b754cd51c6011d90ef03e3f06136f1ebd44658b9529dbcf0c15fc0d6a0b7/notebook-7.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/ea/74c89d786cf3403bfbf8fb70142fdf501af9517d0bb8c1acce3ee5ab613e/pipreqs-0.4.13-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl
@@ -4115,6 +4183,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/5e/d3a6fdf61f6373e53bfb45d6819a72dfef741bc8a9ff31c64496688e7c39/ruff_lsp-0.0.62-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
@@ -4457,25 +4526,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/63/2ab26e4209773223159b83aa32721b4021ffb08102f8ac7d689c943fded1/multidict-6.7.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7c/a3/8ffe10a49652bfd769348c6eca577463c2b3938baab5e62f3896fc5da0b7/pyjson5-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -4805,25 +4880,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/d4/438efabdf74e30aeceb890c3290bbaa449780583b1270b00661126b8aae4/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/ee/f524093232007cd7a75c1d132df70f235cfd590a7c9eaccd7ff422ef4ae8/multidict-6.7.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/06/e4/b751cdf839c011a9714a783f120e6a86b7494eb70044d7d81a25a5cd295f/psutil-7.2.1-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/97/e104682432b02f1458de22478d2b62caa607426e8284bec4680a3537cadd/pyjson5-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -5139,8 +5220,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
@@ -5148,16 +5231,19 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/e2/64bb41266427af6642b6b128e8774ed84c11b80a90702c13ac0a86bb10cc/multidict-6.7.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/2c/78e4a789306a92ade5000da4f5de3255202c534acdadc3aac7b5458fadef/psutil-7.2.1-cp36-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/39/1b/9cd7acea4c0e5a4ed44a79b99fc7e3a50b69639ea9f926efc35d660bef04/pyjson5-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -5460,25 +5546,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/56/982704adea7d3b16614fc5936014e9af85c0e34b58f9046655817f04306e/aiohttp-3.13.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/16/7ed27b680791b939de138f906d5cf2b4657b0d45ca6f5dd6236fdddafb1a/multidict-6.7.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/2a/a758b47de253636e1b8aef181c0b4f4f204bf0dd964914fb2af90a95b49b/propcache-0.4.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/52/8c/1bb60288c4d480a0b51e376a17d6c4d932dc8420989d1db440e3b284aad5/pyjson5-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -5803,25 +5895,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/63/2ab26e4209773223159b83aa32721b4021ffb08102f8ac7d689c943fded1/multidict-6.7.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7c/a3/8ffe10a49652bfd769348c6eca577463c2b3938baab5e62f3896fc5da0b7/pyjson5-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -6137,25 +6235,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/d4/438efabdf74e30aeceb890c3290bbaa449780583b1270b00661126b8aae4/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/ee/f524093232007cd7a75c1d132df70f235cfd590a7c9eaccd7ff422ef4ae8/multidict-6.7.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/06/e4/b751cdf839c011a9714a783f120e6a86b7494eb70044d7d81a25a5cd295f/psutil-7.2.1-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/97/e104682432b02f1458de22478d2b62caa607426e8284bec4680a3537cadd/pyjson5-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -6457,8 +6561,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
@@ -6466,16 +6572,19 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/e2/64bb41266427af6642b6b128e8774ed84c11b80a90702c13ac0a86bb10cc/multidict-6.7.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c5/2c/78e4a789306a92ade5000da4f5de3255202c534acdadc3aac7b5458fadef/psutil-7.2.1-cp36-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/39/1b/9cd7acea4c0e5a4ed44a79b99fc7e3a50b69639ea9f926efc35d660bef04/pyjson5-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -6763,25 +6872,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/56/982704adea7d3b16614fc5936014e9af85c0e34b58f9046655817f04306e/aiohttp-3.13.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/f9/f75b8ff225895f26bda4981b04df68b0ece29aa18aaafe4f21a3e4d82139/botocore-1.42.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/66/da/412cc1711b6c77b7ca852f48b93bae5d8722cdabe86e9427ea2e204dfefd/h5pyd-0.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/16/7ed27b680791b939de138f906d5cf2b4657b0d45ca6f5dd6236fdddafb1a/multidict-6.7.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6b/9a/0939d63f34f1f98db5adc0a2917b4313c27270192ca5e87ce75cd0238ceb/nlr_gaps-0.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/08/b83b94a2b10ee7d27dddff4812a188e6669e520dafccb590613a90fa9d76/nlr_rex-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/2a/a758b47de253636e1b8aef181c0b4f4f204bf0dd964914fb2af90a95b49b/propcache-0.4.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/52/8c/1bb60288c4d480a0b51e376a17d6c4d932dc8420989d1db440e3b284aad5/pyjson5-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/63/86/df4771915e64a564c577ea2573956861c9c9f6c79450b172c5f9277cc48a/requests_unixsocket-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/cf/0af92a4d3f36dd9ff675e0419e7efc48d7808641ac2b2ce2c1f09a9dc632/s3fs-2026.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
@@ -7002,6 +7117,17 @@ packages:
   - pkg:pypi/alabaster?source=hash-mapping
   size: 18684
   timestamp: 1733750512696
+- pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
+  name: alembic
+  version: 1.18.4
+  sha256: a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a
+  requires_dist:
+  - sqlalchemy>=1.4.23
+  - mako
+  - typing-extensions>=4.12
+  - tomli ; python_full_version < '3.11'
+  - tzdata ; extra == 'tz'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
   sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
   md5: 2934f256a8acfe48f6ebb4fce6cde29c
@@ -8964,6 +9090,18 @@ packages:
   - pkg:pypi/colorama?source=hash-mapping
   size: 27011
   timestamp: 1733218222191
+- pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
+  name: colorlog
+  version: 6.10.1
+  sha256: 2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c
+  requires_dist:
+  - colorama ; sys_platform == 'win32'
+  - black ; extra == 'development'
+  - flake8 ; extra == 'development'
+  - mypy ; extra == 'development'
+  - pytest ; extra == 'development'
+  - types-colorama ; extra == 'development'
+  requires_python: '>=3.6'
 - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
   name: comm
   version: 0.2.3
@@ -10066,6 +10204,39 @@ packages:
   - pkg:pypi/gprof2dot?source=hash-mapping
   size: 39376
   timestamp: 1734700339768
+- pypi: https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+  name: greenlet
+  version: 3.5.1
+  sha256: 2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c
+  requires_dist:
+  - sphinx ; extra == 'docs'
+  - furo ; extra == 'docs'
+  - objgraph ; extra == 'test'
+  - psutil ; extra == 'test'
+  - setuptools ; extra == 'test'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl
+  name: greenlet
+  version: 3.5.1
+  sha256: 8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3
+  requires_dist:
+  - sphinx ; extra == 'docs'
+  - furo ; extra == 'docs'
+  - objgraph ; extra == 'test'
+  - psutil ; extra == 'test'
+  - setuptools ; extra == 'test'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
+  name: greenlet
+  version: 3.5.1
+  sha256: 5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea
+  requires_dist:
+  - sphinx ; extra == 'docs'
+  - furo ; extra == 'docs'
+  - objgraph ; extra == 'test'
+  - psutil ; extra == 'test'
+  - setuptools ; extra == 'test'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
   name: h11
   version: 0.16.0
@@ -16251,6 +16422,16 @@ packages:
   - pkg:pypi/makefun?source=hash-mapping
   size: 26779
   timestamp: 1747205193363
+- pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
+  name: mako
+  version: 1.3.12
+  sha256: 8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9
+  requires_dist:
+  - markupsafe>=0.9.2
+  - pytest ; extra == 'testing'
+  - babel ; extra == 'babel'
+  - lingua ; extra == 'lingua'
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.10.0-pyhd8ed1ab_1.conda
   sha256: 967841d300598b17f76ba812e7dae642176692ed2a6735467b93c2b2debe35c1
   md5: cc293b4cad9909bf66ca117ea90d4631
@@ -16853,20 +17034,23 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: nlr-reveal
-  version: 0.2.3.dev5+gcd9a349c7.d20260218
-  sha256: 2aae1db5c4132f29219a349a14eda01c3f21a6e2f5fe7aa4710b74d075766262
+  version: 0.2.4.dev14+g66ba519e5
+  sha256: 345042a0d807cdc6f70488b3e62e5ed0ae5af4b62fdc1044f4f2acc8167ff7c6
   requires_dist:
   - exactextract>=0.3.0,<0.4
   - geopandas>=1.1.1,<2
   - gdal>=3.10.3,<4
+  - joblib>=1.4.0,<2
   - libpysal>=4.13.0,<5
   - nlr-gaps>=0.9.1,<1
   - nlr-rex>=0.5.0,<1
+  - optuna>=4.0.0,<5
   - pandas>=2.3.3,<3
   - pyarrow>=22.0.0,<23
   - pydantic>=2.12.5,<3
   - pyogrio>=0.12.1,<0.13
   - rasterio>=1.4.4,<2
+  - scipy>=1.14.0,<2
   - tqdm>=4.67.1,<5
   - jupyter>=1.0.0,<1.1 ; extra == 'dev'
   - pipreqs>=0.4.13,<0.5 ; extra == 'dev'
@@ -17280,6 +17464,68 @@ packages:
   purls: []
   size: 9440812
   timestamp: 1762841722179
+- pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
+  name: optuna
+  version: 4.8.0
+  sha256: c57a7682679c36bfc9bca0da430698179e513874074b71bebedb0334964ab930
+  requires_dist:
+  - alembic>=1.5.0
+  - colorlog
+  - numpy
+  - packaging>=20.0
+  - sqlalchemy>=1.4.2
+  - tqdm
+  - pyyaml
+  - mypy ; extra == 'checking'
+  - mypy-boto3-s3 ; extra == 'checking'
+  - ruff ; extra == 'checking'
+  - scipy-stubs ; python_full_version >= '3.10' and extra == 'checking'
+  - types-pyyaml ; extra == 'checking'
+  - types-redis ; extra == 'checking'
+  - types-setuptools ; extra == 'checking'
+  - types-tqdm ; extra == 'checking'
+  - typing-extensions>=3.10.0.0 ; extra == 'checking'
+  - ase ; extra == 'document'
+  - cmaes>=0.12.0 ; extra == 'document'
+  - fvcore ; extra == 'document'
+  - kaleido<0.4 ; extra == 'document'
+  - lightgbm ; extra == 'document'
+  - matplotlib!=3.6.0 ; extra == 'document'
+  - pandas ; extra == 'document'
+  - pillow ; extra == 'document'
+  - plotly>=4.9.0 ; extra == 'document'
+  - scikit-learn ; extra == 'document'
+  - sphinx ; extra == 'document'
+  - sphinx-copybutton ; extra == 'document'
+  - sphinx-gallery ; extra == 'document'
+  - sphinx-notfound-page ; extra == 'document'
+  - sphinx-rtd-theme>=1.2.0 ; extra == 'document'
+  - torch ; extra == 'document'
+  - torchvision ; extra == 'document'
+  - boto3 ; extra == 'optional'
+  - cmaes>=0.12.0 ; extra == 'optional'
+  - google-cloud-storage ; extra == 'optional'
+  - matplotlib!=3.6.0 ; extra == 'optional'
+  - pandas ; extra == 'optional'
+  - plotly>=4.9.0 ; extra == 'optional'
+  - redis ; extra == 'optional'
+  - scikit-learn>=0.24.2 ; extra == 'optional'
+  - scipy ; extra == 'optional'
+  - torch ; extra == 'optional'
+  - greenlet ; extra == 'optional'
+  - grpcio ; extra == 'optional'
+  - protobuf>=5.28.1 ; extra == 'optional'
+  - fakeredis[lua] ; extra == 'test'
+  - kaleido<0.4 ; extra == 'test'
+  - moto ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - scipy>=1.9.2 ; extra == 'test'
+  - torch ; extra == 'test'
+  - greenlet ; extra == 'test'
+  - grpcio ; extra == 'test'
+  - protobuf>=5.28.1 ; extra == 'test'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.2.1-hd747db4_0.conda
   sha256: 8d91d6398fc63a94d238e64e4983d38f6f9555460f11bed00abb2da04dbadf7c
   md5: ddab8b2af55b88d63469c040377bd37e
@@ -20473,6 +20719,158 @@ packages:
   - pkg:pypi/sphinxcontrib-serializinghtml?source=hash-mapping
   size: 28669
   timestamp: 1733750596111
+- pypi: https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: sqlalchemy
+  version: 2.0.49
+  sha256: 685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066
+  requires_dist:
+  - importlib-metadata ; python_full_version < '3.8'
+  - greenlet>=1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
+  - typing-extensions>=4.6.0
+  - greenlet>=1 ; extra == 'asyncio'
+  - mypy>=0.910 ; extra == 'mypy'
+  - pyodbc ; extra == 'mssql'
+  - pymssql ; extra == 'mssql-pymssql'
+  - pyodbc ; extra == 'mssql-pyodbc'
+  - mysqlclient>=1.4.0 ; extra == 'mysql'
+  - mysql-connector-python ; extra == 'mysql-connector'
+  - mariadb>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10 ; extra == 'mariadb-connector'
+  - cx-oracle>=8 ; extra == 'oracle'
+  - oracledb>=1.0.1 ; extra == 'oracle-oracledb'
+  - psycopg2>=2.7 ; extra == 'postgresql'
+  - pg8000>=1.29.1 ; extra == 'postgresql-pg8000'
+  - greenlet>=1 ; extra == 'postgresql-asyncpg'
+  - asyncpg ; extra == 'postgresql-asyncpg'
+  - psycopg2-binary ; extra == 'postgresql-psycopg2binary'
+  - psycopg2cffi ; extra == 'postgresql-psycopg2cffi'
+  - psycopg>=3.0.7 ; extra == 'postgresql-psycopg'
+  - psycopg[binary]>=3.0.7 ; extra == 'postgresql-psycopgbinary'
+  - pymysql ; extra == 'pymysql'
+  - greenlet>=1 ; extra == 'aiomysql'
+  - aiomysql>=0.2.0 ; extra == 'aiomysql'
+  - greenlet>=1 ; extra == 'aioodbc'
+  - aioodbc ; extra == 'aioodbc'
+  - greenlet>=1 ; extra == 'asyncmy'
+  - asyncmy>=0.2.3,!=0.2.4,!=0.2.6 ; extra == 'asyncmy'
+  - greenlet>=1 ; extra == 'aiosqlite'
+  - aiosqlite ; extra == 'aiosqlite'
+  - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
+  - sqlcipher3-binary ; extra == 'sqlcipher'
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl
+  name: sqlalchemy
+  version: 2.0.49
+  sha256: 233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e
+  requires_dist:
+  - importlib-metadata ; python_full_version < '3.8'
+  - greenlet>=1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
+  - typing-extensions>=4.6.0
+  - greenlet>=1 ; extra == 'asyncio'
+  - mypy>=0.910 ; extra == 'mypy'
+  - pyodbc ; extra == 'mssql'
+  - pymssql ; extra == 'mssql-pymssql'
+  - pyodbc ; extra == 'mssql-pyodbc'
+  - mysqlclient>=1.4.0 ; extra == 'mysql'
+  - mysql-connector-python ; extra == 'mysql-connector'
+  - mariadb>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10 ; extra == 'mariadb-connector'
+  - cx-oracle>=8 ; extra == 'oracle'
+  - oracledb>=1.0.1 ; extra == 'oracle-oracledb'
+  - psycopg2>=2.7 ; extra == 'postgresql'
+  - pg8000>=1.29.1 ; extra == 'postgresql-pg8000'
+  - greenlet>=1 ; extra == 'postgresql-asyncpg'
+  - asyncpg ; extra == 'postgresql-asyncpg'
+  - psycopg2-binary ; extra == 'postgresql-psycopg2binary'
+  - psycopg2cffi ; extra == 'postgresql-psycopg2cffi'
+  - psycopg>=3.0.7 ; extra == 'postgresql-psycopg'
+  - psycopg[binary]>=3.0.7 ; extra == 'postgresql-psycopgbinary'
+  - pymysql ; extra == 'pymysql'
+  - greenlet>=1 ; extra == 'aiomysql'
+  - aiomysql>=0.2.0 ; extra == 'aiomysql'
+  - greenlet>=1 ; extra == 'aioodbc'
+  - aioodbc ; extra == 'aioodbc'
+  - greenlet>=1 ; extra == 'asyncmy'
+  - asyncmy>=0.2.3,!=0.2.4,!=0.2.6 ; extra == 'asyncmy'
+  - greenlet>=1 ; extra == 'aiosqlite'
+  - aiosqlite ; extra == 'aiosqlite'
+  - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
+  - sqlcipher3-binary ; extra == 'sqlcipher'
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl
+  name: sqlalchemy
+  version: 2.0.49
+  sha256: 77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5
+  requires_dist:
+  - importlib-metadata ; python_full_version < '3.8'
+  - greenlet>=1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
+  - typing-extensions>=4.6.0
+  - greenlet>=1 ; extra == 'asyncio'
+  - mypy>=0.910 ; extra == 'mypy'
+  - pyodbc ; extra == 'mssql'
+  - pymssql ; extra == 'mssql-pymssql'
+  - pyodbc ; extra == 'mssql-pyodbc'
+  - mysqlclient>=1.4.0 ; extra == 'mysql'
+  - mysql-connector-python ; extra == 'mysql-connector'
+  - mariadb>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10 ; extra == 'mariadb-connector'
+  - cx-oracle>=8 ; extra == 'oracle'
+  - oracledb>=1.0.1 ; extra == 'oracle-oracledb'
+  - psycopg2>=2.7 ; extra == 'postgresql'
+  - pg8000>=1.29.1 ; extra == 'postgresql-pg8000'
+  - greenlet>=1 ; extra == 'postgresql-asyncpg'
+  - asyncpg ; extra == 'postgresql-asyncpg'
+  - psycopg2-binary ; extra == 'postgresql-psycopg2binary'
+  - psycopg2cffi ; extra == 'postgresql-psycopg2cffi'
+  - psycopg>=3.0.7 ; extra == 'postgresql-psycopg'
+  - psycopg[binary]>=3.0.7 ; extra == 'postgresql-psycopgbinary'
+  - pymysql ; extra == 'pymysql'
+  - greenlet>=1 ; extra == 'aiomysql'
+  - aiomysql>=0.2.0 ; extra == 'aiomysql'
+  - greenlet>=1 ; extra == 'aioodbc'
+  - aioodbc ; extra == 'aioodbc'
+  - greenlet>=1 ; extra == 'asyncmy'
+  - asyncmy>=0.2.3,!=0.2.4,!=0.2.6 ; extra == 'asyncmy'
+  - greenlet>=1 ; extra == 'aiosqlite'
+  - aiosqlite ; extra == 'aiosqlite'
+  - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
+  - sqlcipher3-binary ; extra == 'sqlcipher'
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  name: sqlalchemy
+  version: 2.0.49
+  sha256: 57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a
+  requires_dist:
+  - importlib-metadata ; python_full_version < '3.8'
+  - greenlet>=1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
+  - typing-extensions>=4.6.0
+  - greenlet>=1 ; extra == 'asyncio'
+  - mypy>=0.910 ; extra == 'mypy'
+  - pyodbc ; extra == 'mssql'
+  - pymssql ; extra == 'mssql-pymssql'
+  - pyodbc ; extra == 'mssql-pyodbc'
+  - mysqlclient>=1.4.0 ; extra == 'mysql'
+  - mysql-connector-python ; extra == 'mysql-connector'
+  - mariadb>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10 ; extra == 'mariadb-connector'
+  - cx-oracle>=8 ; extra == 'oracle'
+  - oracledb>=1.0.1 ; extra == 'oracle-oracledb'
+  - psycopg2>=2.7 ; extra == 'postgresql'
+  - pg8000>=1.29.1 ; extra == 'postgresql-pg8000'
+  - greenlet>=1 ; extra == 'postgresql-asyncpg'
+  - asyncpg ; extra == 'postgresql-asyncpg'
+  - psycopg2-binary ; extra == 'postgresql-psycopg2binary'
+  - psycopg2cffi ; extra == 'postgresql-psycopg2cffi'
+  - psycopg>=3.0.7 ; extra == 'postgresql-psycopg'
+  - psycopg[binary]>=3.0.7 ; extra == 'postgresql-psycopgbinary'
+  - pymysql ; extra == 'pymysql'
+  - greenlet>=1 ; extra == 'aiomysql'
+  - aiomysql>=0.2.0 ; extra == 'aiomysql'
+  - greenlet>=1 ; extra == 'aioodbc'
+  - aioodbc ; extra == 'aioodbc'
+  - greenlet>=1 ; extra == 'asyncmy'
+  - asyncmy>=0.2.3,!=0.2.4,!=0.2.6 ; extra == 'asyncmy'
+  - greenlet>=1 ; extra == 'aiosqlite'
+  - aiosqlite ; extra == 'aiosqlite'
+  - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
+  - sqlcipher3-binary ; extra == 'sqlcipher'
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.51.1-hbc0de68_0.conda
   sha256: f74f6e1302086d84cb62b2bca74950763378054008c77b0a62ac637bcf25b3c1
   md5: 968f50847d17c74a428fc47a2c70fd6f

--- a/pixi.lock
+++ b/pixi.lock
@@ -17034,8 +17034,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: nlr-reveal
-  version: 0.2.4.dev14+g66ba519e5
-  sha256: 345042a0d807cdc6f70488b3e62e5ed0ae5af4b62fdc1044f4f2acc8167ff7c6
+  version: 0.2.4.dev15+ga602ddc77
+  sha256: 5bff02f6a695cd91e0a3e10d6bb66a975ebd79a5dd7bb275d5d593b2e7949312
   requires_dist:
   - exactextract>=0.3.0,<0.4
   - geopandas>=1.1.1,<2
@@ -17050,6 +17050,7 @@ packages:
   - pydantic>=2.12.5,<3
   - pyogrio>=0.12.1,<0.13
   - rasterio>=1.4.4,<2
+  - scikit-learn>=1.4.0,<2
   - scipy>=1.14.0,<2
   - tqdm>=4.67.1,<5
   - jupyter>=1.0.0,<1.1 ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "pydantic>=2.12.5,<3",
   "pyogrio>=0.12.1,<0.13",
   "rasterio>=1.4.4,<2",
+  "scikit-learn>=1.4.0,<2",
   "scipy>=1.14.0,<2",
   "tqdm>=4.67.1,<5",
 ]
@@ -210,6 +211,8 @@ omit = [
   "_version.py",
   # omit log file copied over from other repo
   "reVeal/log.py",
+  # omit adapted third-party PU learning code
+  "reVeal/pu/*",
   # omit pixi files
   ".pixi/*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,14 +33,17 @@ dependencies = [
   "exactextract>=0.3.0,<0.4",
   "geopandas>=1.1.1,<2",
   "gdal>=3.10.3,<4",
+  "joblib>=1.4.0,<2",
   "libpysal>=4.13.0,<5",
   "NLR-GAPs>=0.9.1,<1",
   "NLR-rex>=0.5.0,<1",
+  "optuna>=4.0.0,<5",
   "pandas>=2.3.3,<3",
   "pyarrow>=22.0.0,<23",
   "pydantic>=2.12.5,<3",
   "pyogrio>=0.12.1,<0.13",
   "rasterio>=1.4.4,<2",
+  "scipy>=1.14.0,<2",
   "tqdm>=4.67.1,<5",
 ]
 

--- a/reVeal/cli/cli.py
+++ b/reVeal/cli/cli.py
@@ -9,10 +9,12 @@ from reVeal.cli.characterize import characterize_cmd
 from reVeal.cli.normalize import normalize_cmd
 from reVeal.cli.score_weighted import score_weighted_cmd
 from reVeal.cli.downscale import downscale_cmd
+from reVeal.cli.learn_weights import learn_weights_cmd
 
 logger = logging.getLogger(__name__)
 
-commands = [characterize_cmd, normalize_cmd, score_weighted_cmd, downscale_cmd]
+commands = [characterize_cmd, normalize_cmd, score_weighted_cmd, downscale_cmd,
+            learn_weights_cmd]
 main = make_cli(commands, info={"name": "reVeal", "version": __version__})
 
 # export GAPs commands to namespace for documentation

--- a/reVeal/cli/learn_weights.py
+++ b/reVeal/cli/learn_weights.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""
+cli.learn_weights module - Sets up learn-weights command for use with NLR-GAPs CLI.
+"""
+import json
+import logging
+from pathlib import Path
+
+from pydantic import ValidationError
+from gaps.cli import as_click_command, CLICommandFromFunction
+
+from reVeal.config.learn_weights import LearnWeightsConfig
+from reVeal.log import get_logger, remove_streamhandlers
+from reVeal.learn_weights import run_learn_weights
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _log_inputs(config):
+    """
+    Emit log messages summarizing user inputs.
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary.
+    """
+    LOGGER.info(f"Inputs config: {json.dumps(config, indent=4, default=str)}")
+
+
+def _preprocessor(config, job_name, log_directory, verbose):
+    """
+    Preprocess user-input configuration.
+
+    Parameters
+    ----------
+    config : dict
+        User configuration file input as (nested) dict.
+    job_name : str
+        Name of job being run.
+    verbose : bool
+        Flag to signal DEBUG verbosity.
+
+    Returns
+    -------
+    dict
+        Configuration dictionary modified to include additional parameters.
+    """
+    if verbose:
+        log_level = "DEBUG"
+    else:
+        log_level = "INFO"
+    get_logger(
+        __name__, log_level=log_level, out_path=log_directory / f"{job_name}.log"
+    )
+
+    LOGGER.info("Validating input configuration file")
+    try:
+        learn_config = {
+            k: config.get(k)
+            for k in LearnWeightsConfig.model_fields.keys()
+            if k in config
+        }
+        LearnWeightsConfig(**learn_config)
+    except ValidationError as e:
+        LOGGER.error(
+            "Configuration did not pass validation. "
+            f"The following issues were identified:\n{e}"
+        )
+        raise e
+    LOGGER.info("Input configuration file is valid.")
+
+    config["_local"] = (
+        config.get("execution_control", {}).get("option", "local") == "local"
+    )
+    _log_inputs(config)
+
+    return config
+
+
+def run(
+    grid,
+    labels,
+    out_dir,
+    attributes=None,
+    n_estimators=500,
+    class_prior=None,
+    background_samples=10000,
+    test_size=0.2,
+    validation_size=0.1,
+    n_jobs=1,
+    random_state=42,
+    score_name="suitability_score",
+    crs="EPSG:5070",
+    tune=False,
+    n_trials=20,
+    tuning_metric="auc",
+    _local=True,
+):
+    """
+    Learn feature weights from labeled data using PU (Positive-Unlabeled) learning.
+
+    Trains a PUExtraTrees model on a normalized grid using point labels as positive
+    samples and auto-sampled background cells as unlabeled samples. Outputs a
+    score-weighted configuration JSON with feature importances normalized as weights
+    (summing to 1.0).
+
+    Parameters
+    ----------
+    grid : str
+        Path to the normalized grid (output of ``reVeal normalize``). Must be a
+        vector dataset readable by pyogrio with numeric ``*_score`` columns.
+    labels : str
+        Path to a point geometry dataset (GeoPackage, shapefile, etc.) containing
+        positive sample locations. These represent known sites (e.g., data center
+        locations).
+    out_dir : str
+        Output directory. Results will be saved as ``config_score_weighted.json``
+        and ``learn_weights_metrics.json``.
+    attributes : list of str, optional
+        List of column names from the grid to use as features. If not specified,
+        all columns ending with ``_score`` are used automatically.
+    n_estimators : int, optional
+        Number of trees in the PUExtraTrees forest. Default is 500.
+    class_prior : float, optional
+        Prior probability that a sample is positive. If not specified, computed
+        automatically as ``n_positive / (n_positive + n_background)``.
+    background_samples : int, optional
+        Number of background (unlabeled) cells to sample from non-intersecting
+        grid cells. Default is 10000.
+    test_size : float, optional
+        Fraction of positive cells to hold out for model evaluation. Default is 0.2.
+    validation_size : float, optional
+        Fraction of training positives for validation. Default is 0.1.
+    n_jobs : int, optional
+        Number of parallel jobs for model training. Default is 1.
+    random_state : int, optional
+        Random seed for reproducibility. Default is 42.
+    score_name : str, optional
+        Name of the output score column in the generated config. Default is
+        ``suitability_score``.
+    crs : str, optional
+        Coordinate reference system for spatial operations. Default is ``EPSG:5070``.
+    tune : bool, optional
+        If True and class_prior is not set, use Optuna to find the optimal
+        class_prior by maximizing the tuning_metric on the validation set.
+        Default is False.
+    n_trials : int, optional
+        Number of Optuna trials for hyperparameter tuning. Default is 20.
+    tuning_metric : str, optional
+        Metric to maximize during tuning: 'auc' or 'tpr'. Default is 'auc'.
+    _local : bool
+        Flag indicating local vs HPC execution. Not user-provided.
+    """
+    # pylint: disable=unused-argument
+
+    if _local:
+        remove_streamhandlers(LOGGER.parent)
+
+    config = LearnWeightsConfig(
+        grid=grid,
+        labels=labels,
+        attributes=attributes,
+        n_estimators=n_estimators,
+        class_prior=class_prior,
+        background_samples=background_samples,
+        test_size=test_size,
+        validation_size=validation_size,
+        n_jobs=n_jobs,
+        random_state=random_state,
+        score_name=score_name,
+        crs=crs,
+        tune=tune,
+        n_trials=n_trials,
+        tuning_metric=tuning_metric,
+    )
+
+    LOGGER.info("Running learn-weights pipeline...")
+    results = run_learn_weights(config)
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    # Save score-weighted config
+    config_out = out_path / "config_score_weighted.json"
+    LOGGER.info(f"Saving score-weighted config to {config_out}...")
+    with open(config_out, "w") as f:
+        json.dump(results["config"], f, indent=2)
+
+    # Save metrics
+    if results["metrics"]:
+        metrics_out = out_path / "learn_weights_metrics.json"
+        LOGGER.info(f"Saving metrics to {metrics_out}...")
+        with open(metrics_out, "w") as f:
+            json.dump(results["metrics"], f, indent=2)
+
+    # Save tuning results
+    if results.get("tuning"):
+        tuning_out = out_path / "learn_weights_tuning.json"
+        LOGGER.info(f"Saving tuning results to {tuning_out}...")
+        with open(tuning_out, "w") as f:
+            json.dump(results["tuning"], f, indent=2)
+
+    LOGGER.info("learn-weights complete.")
+
+
+learn_weights_cmd = CLICommandFromFunction(
+    function=run,
+    name="learn-weights",
+    add_collect=False,
+    config_preprocessor=_preprocessor,
+)
+
+main = as_click_command(learn_weights_cmd)
+
+
+if __name__ == "__main__":
+    try:
+        main(obj={})
+    except Exception:
+        LOGGER.exception("Error running reVeal learn-weights command.")
+        raise

--- a/reVeal/config/learn_weights.py
+++ b/reVeal/config/learn_weights.py
@@ -1,0 +1,33 @@
+"""
+config.learn_weights module - Configuration for learn-weights command.
+"""
+from typing import List, Literal, Optional
+
+from pydantic import model_validator, FilePath, Field
+from typing_extensions import Annotated
+
+from reVeal.config.config import BaseModelStrict, BaseGridConfig
+
+
+class LearnWeightsConfig(BaseGridConfig):
+    """
+    Configuration for the learn-weights command.
+
+    Defines inputs for training a PU (Positive-Unlabeled) ExtraTrees model
+    on a normalized grid to derive feature importance weights.
+    """
+
+    labels: FilePath
+    attributes: Optional[List[str]] = None
+    n_estimators: Annotated[int, Field(ge=10, le=10000)] = 500
+    class_prior: Optional[Annotated[float, Field(gt=0, lt=1)]] = None
+    background_samples: Annotated[int, Field(ge=100)] = 10000
+    test_size: Annotated[float, Field(gt=0, lt=1)] = 0.2
+    validation_size: Annotated[float, Field(gt=0, lt=1)] = 0.1
+    n_jobs: Annotated[int, Field(ge=1)] = 1
+    random_state: int = 42
+    score_name: str = "suitability_score"
+    crs: str = "EPSG:5070"
+    tune: bool = False
+    n_trials: Annotated[int, Field(ge=1, le=1000)] = 20
+    tuning_metric: Literal["auc", "tpr"] = "auc"

--- a/reVeal/config/learn_weights.py
+++ b/reVeal/config/learn_weights.py
@@ -3,10 +3,10 @@ config.learn_weights module - Configuration for learn-weights command.
 """
 from typing import List, Literal, Optional
 
-from pydantic import model_validator, FilePath, Field
+from pydantic import FilePath, Field
 from typing_extensions import Annotated
 
-from reVeal.config.config import BaseModelStrict, BaseGridConfig
+from reVeal.config.config import BaseGridConfig
 
 
 class LearnWeightsConfig(BaseGridConfig):

--- a/reVeal/learn_weights.py
+++ b/reVeal/learn_weights.py
@@ -1,0 +1,495 @@
+"""
+learn_weights module - Core logic for PU learning-based weight derivation.
+
+Trains a PUExtraTrees model on a normalized grid using point labels as positive
+samples and auto-sampled background cells as unlabeled samples. Produces a
+score-weighted configuration with feature importances normalized as weights.
+"""
+import json
+import logging
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import optuna
+from sklearn.metrics import roc_auc_score
+
+from reVeal.pu import PUExtraTrees
+
+logger = logging.getLogger(__name__)
+
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+
+def prepare_pu_data(
+    grid_df,
+    labels_gdf,
+    attributes,
+    background_samples=10000,
+    test_size=0.2,
+    validation_size=0.1,
+    random_state=42,
+):
+    """
+    Prepare positive and unlabeled data splits from a grid and point labels.
+
+    Performs a spatial join of labels onto the grid to identify positive cells,
+    then samples background (unlabeled) cells from non-intersecting cells.
+
+    Parameters
+    ----------
+    grid_df : gpd.GeoDataFrame
+        Normalized grid with score attributes and a 'gid' column.
+    labels_gdf : gpd.GeoDataFrame
+        Point geometries representing positive label locations.
+    attributes : list of str
+        Column names to use as features.
+    background_samples : int
+        Number of background (unlabeled) cells to sample.
+    test_size : float
+        Fraction of positive cells to hold out for testing.
+    validation_size : float
+        Fraction of remaining positive cells for validation.
+    random_state : int
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys: 'train_gids', 'validation_gids', 'test_gids',
+        'background_gids', 'background_test_gids', 'background_val_gids'.
+    """
+    if "gid" not in grid_df.columns:
+        grid_df = grid_df.copy()
+        grid_df["gid"] = grid_df.index
+
+    joined = gpd.sjoin(grid_df, labels_gdf, how="left", predicate="intersects")
+    intersecting_mask = ~joined["index_right"].isna()
+    all_positive_gids = joined[intersecting_mask]["gid"].unique()
+    non_intersecting_gids = grid_df["gid"][
+        ~grid_df["gid"].isin(all_positive_gids)
+    ].values
+
+    logger.info(
+        f"Found {len(all_positive_gids)} positive cells, "
+        f"{len(non_intersecting_gids)} non-intersecting cells."
+    )
+
+    rng = np.random.default_rng(random_state)
+
+    # Split positives into train / test
+    shuffled = rng.permutation(all_positive_gids)
+    test_count = int(len(shuffled) * test_size)
+    test_gids = shuffled[:test_count]
+    remaining = shuffled[test_count:]
+
+    # Split remaining positives into train / validation
+    val_count = int(len(remaining) * validation_size)
+    validation_gids = remaining[:val_count]
+    train_gids = remaining[val_count:]
+
+    # Sample background
+    remaining_bg = non_intersecting_gids.copy()
+    rng.shuffle(remaining_bg)
+
+    bg_total = min(background_samples, len(remaining_bg))
+    background_gids = remaining_bg[:bg_total]
+    remaining_bg = remaining_bg[bg_total:]
+
+    # Background for test and validation (equal to positive counts)
+    bg_test_count = min(len(test_gids), len(remaining_bg))
+    background_test_gids = remaining_bg[:bg_test_count]
+    remaining_bg = remaining_bg[bg_test_count:]
+
+    bg_val_count = min(len(validation_gids), len(remaining_bg))
+    background_val_gids = remaining_bg[:bg_val_count]
+
+    logger.info(
+        f"Splits: train={len(train_gids)}, val={len(validation_gids)}, "
+        f"test={len(test_gids)}, bg={len(background_gids)}, "
+        f"bg_test={len(background_test_gids)}, bg_val={len(background_val_gids)}"
+    )
+
+    return {
+        "train_gids": train_gids,
+        "validation_gids": validation_gids,
+        "test_gids": test_gids,
+        "background_gids": background_gids,
+        "background_test_gids": background_test_gids,
+        "background_val_gids": background_val_gids,
+    }
+
+
+def train_pu_model(grid_df, data_splits, attributes, n_estimators=500,
+                   class_prior=None, n_jobs=1, random_state=42):
+    """
+    Train a PUExtraTrees model and extract feature importances.
+
+    Parameters
+    ----------
+    grid_df : gpd.GeoDataFrame
+        Grid with feature columns.
+    data_splits : dict
+        Output from prepare_pu_data with gid arrays.
+    attributes : list of str
+        Feature column names.
+    n_estimators : int
+        Number of trees in the forest.
+    class_prior : float or None
+        Prior probability of positive class. If None, auto-computed.
+    n_jobs : int
+        Number of parallel jobs for training.
+    random_state : int
+        Random seed.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys: 'model', 'feature_importances', 'metrics'.
+    """
+    g = grid_df
+
+    # Build training arrays
+    p_tr = g[g["gid"].isin(data_splits["train_gids"])][attributes].to_numpy()
+    u_tr = g[g["gid"].isin(data_splits["background_gids"])][attributes].to_numpy()
+
+    if class_prior is None:
+        class_prior = len(p_tr) / (len(p_tr) + len(u_tr))
+        logger.info(f"Auto-computed class_prior: {class_prior:.4f}")
+
+    # Train model
+    model = PUExtraTrees(
+        n_estimators=n_estimators,
+        risk_estimator="nnPU",
+        n_jobs=n_jobs,
+        random_state=random_state,
+    )
+    logger.info(f"Training PUExtraTrees with {n_estimators} trees...")
+    model.fit(P=p_tr, U=u_tr, pi=class_prior)
+    logger.info("Training complete.")
+
+    # Feature importances
+    importances = model.feature_importances()
+
+    # Evaluate on test set if available
+    metrics = {}
+    if (len(data_splits["test_gids"]) > 0
+            and len(data_splits["background_test_gids"]) > 0):
+        p_test = g[g["gid"].isin(data_splits["test_gids"])][attributes].to_numpy()
+        u_test = g[g["gid"].isin(data_splits["background_test_gids"])][
+            attributes
+        ].to_numpy()
+        x_test = np.vstack((p_test, u_test))
+        y_test = np.concatenate((
+            np.ones(len(p_test), dtype=int),
+            np.zeros(len(u_test), dtype=int),
+        ))
+        y_pred = (model.predict(x_test) == 1).astype(int)
+        metrics["auc"] = float(roc_auc_score(y_test, y_pred))
+        tpr = y_pred[y_test == 1].sum() / y_test.sum()
+        metrics["tpr"] = float(tpr)
+        logger.info(f"Test metrics: AUC={metrics['auc']:.4f}, TPR={metrics['tpr']:.4f}")
+
+    return {
+        "model": model,
+        "feature_importances": importances,
+        "metrics": metrics,
+    }
+
+
+def _compute_metric(grid_df, data_splits, attributes, class_prior, n_estimators,
+                    n_jobs, random_state, metric="auc"):
+    """
+    Train a model with the given class_prior and return the specified metric
+    evaluated on the validation set.
+
+    Parameters
+    ----------
+    grid_df : gpd.GeoDataFrame
+        Grid with feature columns.
+    data_splits : dict
+        Output from prepare_pu_data.
+    attributes : list of str
+        Feature column names.
+    class_prior : float
+        Prior probability of positive class.
+    n_estimators : int
+        Number of trees.
+    n_jobs : int
+        Parallel jobs.
+    random_state : int
+        Random seed.
+    metric : str
+        Metric to compute: 'auc' or 'tpr'.
+
+    Returns
+    -------
+    float
+        Metric value on validation set.
+    """
+    g = grid_df
+    p_tr = g[g["gid"].isin(data_splits["train_gids"])][attributes].to_numpy()
+    u_tr = g[g["gid"].isin(data_splits["background_gids"])][attributes].to_numpy()
+
+    model = PUExtraTrees(
+        n_estimators=n_estimators,
+        risk_estimator="nnPU",
+        n_jobs=n_jobs,
+        random_state=random_state,
+    )
+    model.fit(P=p_tr, U=u_tr, pi=class_prior)
+
+    # Evaluate on validation set
+    p_val = g[g["gid"].isin(data_splits["validation_gids"])][attributes].to_numpy()
+    u_val = g[g["gid"].isin(data_splits["background_val_gids"])][attributes].to_numpy()
+
+    if len(p_val) == 0 or len(u_val) == 0:
+        return 0.0
+
+    x_val = np.vstack((p_val, u_val))
+    y_val = np.concatenate((
+        np.ones(len(p_val), dtype=int),
+        np.zeros(len(u_val), dtype=int),
+    ))
+    y_pred = (model.predict(x_val) == 1).astype(int)
+
+    if metric == "auc":
+        return float(roc_auc_score(y_val, y_pred))
+    elif metric == "tpr":
+        return float(y_pred[y_val == 1].sum() / y_val.sum())
+    else:
+        raise ValueError(f"Unknown metric: {metric}. Use 'auc' or 'tpr'.")
+
+
+def tune_class_prior(grid_df, data_splits, attributes, n_estimators=500,
+                     n_jobs=1, random_state=42, n_trials=20, metric="auc"):
+    """
+    Use Optuna to find the optimal class_prior for PUExtraTrees.
+
+    Parameters
+    ----------
+    grid_df : gpd.GeoDataFrame
+        Grid with feature columns.
+    data_splits : dict
+        Output from prepare_pu_data.
+    attributes : list of str
+        Feature column names.
+    n_estimators : int
+        Number of trees per trial.
+    n_jobs : int
+        Parallel jobs for each model training.
+    random_state : int
+        Random seed.
+    n_trials : int
+        Number of Optuna trials.
+    metric : str
+        Metric to maximize: 'auc' or 'tpr'.
+
+    Returns
+    -------
+    dict
+        Dictionary with 'best_class_prior' and 'best_value'.
+    """
+    logger.info(
+        f"Tuning class_prior with {n_trials} trials, optimizing '{metric}'..."
+    )
+
+    def objective(trial):
+        class_prior = trial.suggest_float("class_prior", 0.01, 0.99)
+        return _compute_metric(
+            grid_df=grid_df,
+            data_splits=data_splits,
+            attributes=attributes,
+            class_prior=class_prior,
+            n_estimators=n_estimators,
+            n_jobs=n_jobs,
+            random_state=random_state,
+            metric=metric,
+        )
+
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=n_trials)
+
+    best_prior = study.best_params["class_prior"]
+    best_value = study.best_value
+    logger.info(
+        f"Tuning complete. Best class_prior={best_prior:.4f}, "
+        f"best {metric}={best_value:.4f}"
+    )
+
+    return {"best_class_prior": best_prior, "best_value": best_value}
+
+
+def importances_to_weights(feature_importances, attributes):
+    """
+    Convert raw feature importances to normalized weights (sum=1).
+
+    Features with importance <= 0 are excluded.
+
+    Parameters
+    ----------
+    feature_importances : np.ndarray
+        Raw importances from PUExtraTrees.feature_importances().
+    attributes : list of str
+        Feature column names (same order as importances).
+
+    Returns
+    -------
+    list of dict
+        List of {"attribute": name, "weight": float} sorted by weight descending.
+        Only includes features with positive importance.
+    """
+    mask = feature_importances > 0
+    valid_attrs = [a for a, m in zip(attributes, mask) if m]
+    valid_importances = feature_importances[mask]
+
+    total = valid_importances.sum()
+    if total == 0:
+        raise ValueError(
+            "All feature importances are <= 0. Cannot derive weights. "
+            "Check that the label set intersects the grid and features vary."
+        )
+
+    weights = valid_importances / total
+
+    result = [
+        {"attribute": attr, "weight": float(w)}
+        for attr, w in zip(valid_attrs, weights)
+    ]
+    result.sort(key=lambda x: x["weight"], reverse=True)
+    return result
+
+
+def generate_score_weighted_config(weights, grid_path, score_name="suitability_score"):
+    """
+    Generate a score-weighted configuration dictionary.
+
+    Parameters
+    ----------
+    weights : list of dict
+        Output from importances_to_weights.
+    grid_path : str
+        Path to the normalized grid (for the output config).
+    score_name : str
+        Name for the output score column.
+
+    Returns
+    -------
+    dict
+        Configuration dictionary compatible with ScoreWeightedConfig.
+    """
+    return {
+        "grid": str(grid_path),
+        "attributes": weights,
+        "score_name": score_name,
+    }
+
+
+def run_learn_weights(config):
+    """
+    Full pipeline: read data, train PU model, output weight config.
+
+    Parameters
+    ----------
+    config : LearnWeightsConfig
+        Validated configuration object.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys: 'config' (score_weighted config dict),
+        'metrics' (model evaluation metrics), 'model' (trained PUExtraTrees).
+    """
+    # Read grid
+    logger.info(f"Reading grid from {config.grid}...")
+    grid_df = gpd.read_file(config.grid, engine="pyogrio", use_arrow=True)
+    grid_df.fillna(0, inplace=True)
+
+    # Read labels
+    logger.info(f"Reading labels from {config.labels}...")
+    labels_gdf = gpd.read_file(config.labels, engine="pyogrio", use_arrow=True)
+
+    # Ensure matching CRS
+    grid_crs = grid_df.crs
+    if labels_gdf.crs != grid_crs:
+        logger.info(f"Reprojecting labels to grid CRS ({grid_crs})...")
+        labels_gdf = labels_gdf.to_crs(grid_crs)
+
+    # Resolve attributes
+    attributes = config.attributes
+    if attributes is None:
+        attributes = [c for c in grid_df.columns if c.endswith("_score")]
+        logger.info(f"Auto-detected {len(attributes)} score attributes.")
+
+    if not attributes:
+        raise ValueError(
+            "No attributes found. Provide 'attributes' in the config or ensure "
+            "the grid has columns ending with '_score'."
+        )
+
+    # Ensure gid column
+    if "gid" not in grid_df.columns:
+        grid_df["gid"] = grid_df.index
+
+    # Filter to cells with valid developable area if column exists
+    if "developable_area_m2_score" in grid_df.columns:
+        grid_df = grid_df[grid_df["developable_area_m2_score"] > 0]
+        logger.info(
+            f"Filtered to {len(grid_df)} cells with developable_area_m2_score > 0."
+        )
+
+    # Prepare data
+    data_splits = prepare_pu_data(
+        grid_df=grid_df,
+        labels_gdf=labels_gdf,
+        attributes=attributes,
+        background_samples=config.background_samples,
+        test_size=config.test_size,
+        validation_size=config.validation_size,
+        random_state=config.random_state,
+    )
+
+    # Tune class_prior if requested
+    class_prior = config.class_prior
+    tuning_results = None
+    if config.tune and class_prior is None:
+        tuning_results = tune_class_prior(
+            grid_df=grid_df,
+            data_splits=data_splits,
+            attributes=attributes,
+            n_estimators=config.n_estimators,
+            n_jobs=config.n_jobs,
+            random_state=config.random_state,
+            n_trials=config.n_trials,
+            metric=config.tuning_metric,
+        )
+        class_prior = tuning_results["best_class_prior"]
+
+    # Train model
+    results = train_pu_model(
+        grid_df=grid_df,
+        data_splits=data_splits,
+        attributes=attributes,
+        n_estimators=config.n_estimators,
+        class_prior=class_prior,
+        n_jobs=config.n_jobs,
+        random_state=config.random_state,
+    )
+
+    # Convert to weights
+    weights = importances_to_weights(results["feature_importances"], attributes)
+    logger.info(f"Derived {len(weights)} non-zero weights from {len(attributes)} features.")
+
+    # Generate output config
+    score_config = generate_score_weighted_config(
+        weights=weights,
+        grid_path=str(config.grid),
+        score_name=config.score_name,
+    )
+
+    return {
+        "config": score_config,
+        "metrics": results["metrics"],
+        "model": results["model"],
+        "tuning": tuning_results,
+    }

--- a/reVeal/learn_weights.py
+++ b/reVeal/learn_weights.py
@@ -5,9 +5,7 @@ Trains a PUExtraTrees model on a normalized grid using point labels as positive
 samples and auto-sampled background cells as unlabeled samples. Produces a
 score-weighted configuration with feature importances normalized as weights.
 """
-import json
 import logging
-from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
@@ -24,7 +22,6 @@ optuna.logging.set_verbosity(optuna.logging.WARNING)
 def prepare_pu_data(
     grid_df,
     labels_gdf,
-    attributes,
     background_samples=10000,
     test_size=0.2,
     validation_size=0.1,
@@ -42,8 +39,6 @@ def prepare_pu_data(
         Normalized grid with score attributes and a 'gid' column.
     labels_gdf : gpd.GeoDataFrame
         Point geometries representing positive label locations.
-    attributes : list of str
-        Column names to use as features.
     background_samples : int
         Number of background (unlabeled) cells to sample.
     test_size : float
@@ -153,9 +148,27 @@ def train_pu_model(grid_df, data_splits, attributes, n_estimators=500,
     p_tr = g[g["gid"].isin(data_splits["train_gids"])][attributes].to_numpy()
     u_tr = g[g["gid"].isin(data_splits["background_gids"])][attributes].to_numpy()
 
+    if len(p_tr) == 0:
+        raise ValueError(
+            "No positive training samples found. Ensure that the labels "
+            "spatially intersect the grid."
+        )
+    if len(u_tr) == 0:
+        raise ValueError(
+            "No background (unlabeled) training samples found. Ensure that "
+            "the grid has cells that do not intersect the labels."
+        )
+
     if class_prior is None:
         class_prior = len(p_tr) / (len(p_tr) + len(u_tr))
         logger.info(f"Auto-computed class_prior: {class_prior:.4f}")
+
+    if not (0 < class_prior < 1):
+        raise ValueError(
+            f"class_prior must be between 0 and 1 (exclusive), got {class_prior}. "
+            "This can happen when all grid cells are labeled as positive or "
+            "no positive samples are found."
+        )
 
     # Train model
     model = PUExtraTrees(
@@ -185,7 +198,8 @@ def train_pu_model(grid_df, data_splits, attributes, n_estimators=500,
             np.zeros(len(u_test), dtype=int),
         ))
         y_pred = (model.predict(x_test) == 1).astype(int)
-        metrics["auc"] = float(roc_auc_score(y_test, y_pred))
+        y_score = model.predict_proba(x_test)
+        metrics["auc"] = float(roc_auc_score(y_test, y_score))
         tpr = y_pred[y_test == 1].sum() / y_test.sum()
         metrics["tpr"] = float(tpr)
         logger.info(f"Test metrics: AUC={metrics['auc']:.4f}, TPR={metrics['tpr']:.4f}")
@@ -254,7 +268,8 @@ def _compute_metric(grid_df, data_splits, attributes, class_prior, n_estimators,
     y_pred = (model.predict(x_val) == 1).astype(int)
 
     if metric == "auc":
-        return float(roc_auc_score(y_val, y_pred))
+        y_score = model.predict_proba(x_val)
+        return float(roc_auc_score(y_val, y_score))
     elif metric == "tpr":
         return float(y_pred[y_val == 1].sum() / y_val.sum())
     else:
@@ -442,7 +457,6 @@ def run_learn_weights(config):
     data_splits = prepare_pu_data(
         grid_df=grid_df,
         labels_gdf=labels_gdf,
-        attributes=attributes,
         background_samples=config.background_samples,
         test_size=config.test_size,
         validation_size=config.validation_size,

--- a/reVeal/pu/__init__.py
+++ b/reVeal/pu/__init__.py
@@ -1,0 +1,4 @@
+"""PU Learning - Positive-Unlabeled ExtraTrees classifier."""
+from reVeal.pu.trees import PUExtraTrees
+
+__all__ = ["PUExtraTrees"]

--- a/reVeal/pu/tree.py
+++ b/reVeal/pu/tree.py
@@ -1,0 +1,516 @@
+# PU ExtraTree - A DT Classifier for PU Learning
+# Adapted from https://github.com/jonathanwilton/PUExtraTrees
+import numpy as np
+import scipy.stats
+import scipy.sparse
+
+class PUExtraTree:
+    def __init__(self, risk_estimator = "nnPU",
+                 loss = "quadratic",
+                 max_depth = None, 
+                 min_samples_leaf = 1, 
+                 max_features = "sqrt", 
+                 max_candidates = 1,
+                 random_state = None):
+        
+        """
+        
+        Parameters
+        ----------
+        risk_estimator : {"PN", "uPU", "nnPU"}, default='nnPU'
+            PU data based risk estimator. Supports supervised (PN) learning, unbiased PU (uPU) learning and nonnegative PU (nnPU) learning.
+        loss : {"quadratic", "logistic"}, default='quadratic'
+            The function to measure the cost of making an incorrect prediction. Supported loss functions are:
+            "quadratic" l(v,y) = (1-vy)^2 and 
+            "logistic" l(v,y) = ln(1+exp(-vy)).
+        max_depth : int or None, default=None
+            The maximum depth of the tree. If None, then nodes are expanded until all leaves are pure or until all leaves contain less than min_samples_leaf samples. 
+        min_samples_leaf : int, default=1
+            The minimum number of samples required to be at a leaf node. The default is 1.
+        max_features : int or {"sqrt", "all"}, default="sqrt"
+            The number of features to consider when looking for the best split. If "sqrt", then max_features = ceil(sqrt(n_features)). If "all", then max_features = n_features. 
+        max_candidates : int, default=1
+            Number of randomly chosen split points to consider for each candidate feature. 
+        random_state : int or None, default=None
+            Seed for the random number generator. If None, the random number generator is not seeded.
+
+        Returns
+        -------
+        None.
+
+        """
+        
+        self.risk_estimator = risk_estimator
+        self.loss = loss
+        self.max_depth = max_depth
+        self.min_samples_leaf = min_samples_leaf
+        self.max_features = max_features
+        self.max_candidates = max_candidates
+        self.random_state = random_state
+        
+        # Initialize random number generator for this tree
+        if random_state is not None:
+            self.rng = np.random.default_rng(seed=random_state)
+        else:
+            self.rng = np.random.default_rng()
+        
+        self.is_trained = False # indicate if tree empty/trained
+        self.leaf_count = 0
+        self.current_max_depth = 0
+        self.nodes = {(0,0): {'data': None, 'j': None, 'xi': None, 'g': None, 
+                              'is_leaf': None, 'risk_reduction': None}}
+        
+        
+    def create_successor(self, node, side):
+        """
+        Create an empty child node (either T or F) in the tree.
+        Parameters
+        ----------
+        node : tuple of length 2.
+            The parent node. First element is the depth in the tree, second element is the position at that depth.
+        side : {"T", "F"} or {"L", "R"}
+            Whether the node corresponds to a True or False split.
+        Returns
+        -------
+        None.
+        
+        """
+        
+        row, column = node
+        if side in ['T','L']:
+            self.nodes[(row+1, 2*column)] = {'data': None, 'j': None, 
+                                                   'xi': None, 'g': None, 
+                                                   'is_leaf': None, 'loss': None, 
+                                                   'risk_reduction': None}
+        elif side in ['F','R']:
+            self.nodes[(row+1, 2*column+1)] = {'data': None, 'j': None, 
+                                                     'xi': None, 'g': None,
+                                                     'is_leaf': None, 'loss': None,
+                                                     'risk_reduction': None}
+        elif side not in ['T','F','L','R']:
+            print('choose valid position of child node: \'L\', \'R\', \'T\', \'F\'')
+    
+    
+    
+    def get_parent(self, node, return_truth_val):
+        """
+        Return parent node, and optionally the relationship to child node (T/F).
+        
+        Parameters
+        ----------
+        node : tuple of length 2
+            The child node.
+        return_truth_val : bool
+            Indicate whether the truth value should also be returned, that is, whether the child node corresponds to a true or false split.
+        Returns
+        -------
+        tuple of length 2 or (tuple of length 2, bool)
+            The parent node, optionally the relationships to the parent nodes.
+        
+        """        
+        
+        parent = (node[0] - 1, node[1] // 2)
+        if return_truth_val:
+            if node[1] % 2 == 0:
+                return parent, True
+            else:
+                return parent, False
+        else:
+            return parent
+        
+    
+    
+    def get_ancestory(self, node):
+        """
+        Get parent nodes and relationship to the child nodes all the way to the root. 
+        
+        Parameters
+        ----------
+        node : tuple of length 2
+            Child node.
+
+        Returns
+        -------
+        list
+            List of nodes.
+        bools : list
+            List of bools with the relationships to the parents.
+        
+        """
+        chain = [node]
+        bools = []
+        while chain[-1] != (0,0):
+            parent, relationship = self.get_parent(chain[-1], True)
+            chain += [parent]
+            bools += [relationship]
+        
+        return chain[1:], bools
+
+
+    def load_tree(self, nodes):
+        """
+        Load saved tree.
+
+        Parameters
+        ----------
+        nodes : dictionary
+            Dictionary describing the trained decision tree. Typically output from self.nodes.
+
+        Returns
+        -------
+        None.
+
+        """
+
+        self.nodes = nodes
+        self.is_trained = True
+        
+    
+
+
+    def fit(self, pi, P = None, U = None, N = None):
+        """
+        Fit the decision tree.
+
+        Parameters
+        ----------
+        pi : float
+            Prior probability that an example belongs to the positive class. 
+        P : array-like of shape (n_p, n_features), default=None
+            Training samples from the positive class.
+        U : array-like of shape (n_u, n_features), default=None
+            Unlabeled training samples.
+        N : array-like of shape (n_n, n_features), default=None
+            Training samples from the negative class if performing PN learning.
+
+        Returns
+        -------
+        self
+            Returns instance of self.
+
+        """
+        if self.risk_estimator in ['uPU', 'nnPU']:
+            X = np.concatenate((P, U), axis = 0)
+            y = np.concatenate((np.ones(len(P)), np.zeros(len(U))))
+        elif self.risk_estimator in ['PN']:
+            X = np.concatenate((P, N), axis = 0)
+            y = np.concatenate((np.ones(len(P)), -np.ones(len(N))))
+        
+        # X = X.astype(np.float32)
+        y = y.astype(np.int8).flatten()
+        n, self.d = X.shape
+        n_p = (y == 1).sum()
+        n_u = (y == 0).sum()
+        n_n = (y == -1).sum()
+        self.pi = pi
+        
+        if self.pi is None:
+            print('please specify pi')
+                
+        if self.max_features == 'sqrt':
+            self.max_features = int(np.ceil(np.sqrt(X.shape[1])))
+        elif self.max_features == 'all':
+            self.max_features = X.shape[1]
+        elif self.max_features in [i for i in range(1, self.d+1)]:
+            None
+        else:
+            print('select valid number of max features to consider splitting on.')
+            return None
+        
+        
+        self.nodes[(0,0)]['data'] = scipy.sparse.coo_matrix(np.ones(n).astype(bool))
+        
+        def data_at_node(node):
+            # return subset of training data in partition specified by certain node            
+            
+            if self.nodes[node]['data'] is not None:
+                return self.nodes[node]['data'].toarray()[0]
+            else:
+                # get indices of data at parent
+                parent_node, relationship = self.get_parent(node, True)
+                ind_parent = self.nodes[parent_node]['data'].toarray()[0].copy()
+                checks = (X[ind_parent, self.nodes[parent_node]['j']] <= self.nodes[parent_node]['xi']) == relationship
+                ind_parent[ind_parent] = checks.flatten()
+                self.nodes[node]['data'] = scipy.sparse.coo_matrix(ind_parent)
+                return ind_parent
+        
+        
+        def impurity_node(y_sigma):
+            # impurity of single node
+            if self.risk_estimator in ["uPU", "nnPU"]:
+                Wp = (y_sigma == 1).sum() * self.pi/n_p
+                Wn = (y_sigma == 0).sum()/n_u - Wp
+                
+                if Wp + Wn == 0:
+                    vstar = float('inf')
+                else:
+                    vstar = Wp/(Wp + Wn)
+                    
+            elif self.risk_estimator in ['PN']:
+                Wp = (y_sigma == 1).sum() * self.pi/n_p
+                Wn = (y_sigma == -1).sum() * (1-self.pi)/n_n
+                
+                if Wp + Wn == 0:
+                    vstar = float('inf')
+                else:
+                    vstar = Wp/(Wp + Wn)
+            
+            
+            if self.loss == "quadratic":
+                if self.risk_estimator == "uPU" and vstar == float('inf'):
+                    return -float('inf')
+                elif self.risk_estimator == "nnPU" and vstar > 1:
+                    return 0
+                else:
+                    return 4 * (Wp + Wn) * vstar * (1 - vstar)
+            
+            elif self.loss == "logistic":
+                if self.risk_estimator == "uPU" and vstar > 1:
+                    return -float('inf')
+                elif self.risk_estimator in ["uPU", "nnPU", "PN"] and vstar in [0,1]:
+                    return 0
+                elif self.risk_estimator == "nnPU" and vstar > 1:
+                    return 0
+                else:
+                    return (Wp + Wn) * (-vstar*np.log(vstar) - (1-vstar)*np.log(1-vstar))
+        
+        
+        def impurity_split(sigma, j, xi):
+            mask = (X[sigma, j] <= xi).flatten()
+            imT = impurity_node(y[sigma][mask])
+            imF = impurity_node(y[sigma][~mask])
+            return imT + imF
+        
+
+        def regional_prediction_function(y_sigma):            
+            if self.risk_estimator in ["uPU", "nnPU"]:
+                Wp = (y_sigma == 1).sum() * self.pi/n_p
+                Wn = (y_sigma == 0).sum()/n_u - Wp
+                
+                if Wp + Wn == 0:
+                    vstar = float('inf')
+                else:
+                    vstar = Wp/(Wp + Wn)
+            
+            elif self.risk_estimator in ["PN"]:
+                Wp = (y_sigma == 1).sum() * self.pi/n_p
+                Wn = (y_sigma == -1).sum() * (1-self.pi)/n_n
+                
+                if Wp + Wn == 0:
+                    vstar = float('inf')
+                else:
+                    vstar = Wp/(Wp + Wn)
+            
+            if vstar > 0.5:
+                return 1
+            elif vstar < 0.5:
+                return -1
+            elif vstar == 0.5:
+                # Use tree's own RNG for deterministic tie-breaking
+                return 2*self.rng.binomial(1, 0.5) - 1
+            
+
+        def construct_subtree(node, sigma):                
+            # FIRST: Check for empty node before any operations
+            if sigma.sum() == 0:
+                self.nodes[node]['is_leaf'] = True
+                self.nodes[node]['g'] = 0  # Default prediction for empty node
+                self.nodes[node]['risk_reduction'] = 0
+                self.leaf_count += 1
+                return
+            
+            # Now check other stopping criteria
+            impurity = impurity_node(y[sigma])
+            
+            # check node pure
+            if self.risk_estimator in ['nnPU', 'PN']:
+                c1 = impurity > 0 
+            elif self.risk_estimator == 'uPU':
+                if y[sigma].sum() == 0:
+                    c1 = impurity > 0           
+                else:
+                    c1 = impurity > -float('inf')            
+            
+            # check max depth reached
+            if self.max_depth is None:
+                c2 = True
+            else:
+                c2 = node[0] < self.max_depth
+    
+            # minimum samples in node reached
+            c3 = self.min_samples_leaf < sigma.sum()
+    
+            # Check for variability in features (already safe now since we checked sigma.sum() > 0)
+            att_ptp = np.ptp(X[sigma], axis=0)
+            c4 = att_ptp.sum() > 0
+    
+            # check if any of the criteria satisfied
+            # if so, turn into a leaf node
+            if c1*c2*c3*c4 == 0:
+                self.nodes[node]['is_leaf'] = True
+                lab = regional_prediction_function(y[sigma])
+                self.nodes[node]['g'] = lab
+                self.nodes[node]['risk_reduction'] = 0
+                self.leaf_count += 1
+            else:
+                self.nodes[node]['is_leaf'] = False
+                # find valid nodes that can be used for a split
+                atts = []
+                for i in range(self.d):
+                    if att_ptp[i] > 0:
+                        atts += [i]
+                
+                # Use tree's own RNG for deterministic feature selection
+                attributes = self.rng.choice(atts, size = min(self.max_features, len(atts)), replace = False)
+                candidates = []
+                candidate_attributes = []
+                candidate_cut_points = []
+                for i in range(len(attributes)):
+                    for j in range(self.max_candidates):
+                        # need to guard against errors caused by finite precision
+                        a_,b_,c_,d_ = np.unique(X[sigma, attributes[i]])[[0,1,-2,-1]]                        
+                        # Use tree's own RNG for deterministic cut point generation
+                        cut_point = self.rng.uniform(a_ + 2*(b_-a_)/5, c_ + 3*(d_-c_)/5)
+                        candidates += [[attributes[i], cut_point]]
+                        candidate_attributes += [attributes[i]]
+                        candidate_cut_points += [cut_point]
+                
+                impurities = []
+                for i in range(len(candidates)):
+                    impurities += [impurity_split(sigma, candidate_attributes[i], candidate_cut_points[i])]
+                
+                minimiser = np.argmin(impurities)
+                best_attribute = candidate_attributes[minimiser]
+                best_cut_point = candidate_cut_points[minimiser]
+                
+                self.nodes[node]['j'] = int(best_attribute)
+                self.nodes[node]['xi'] = best_cut_point
+                self.nodes[node]['risk_reduction'] = impurity - impurities[minimiser]
+            
+                # create successors of current node
+                self.create_successor(node, 'T')
+                self.create_successor(node, 'F')
+                
+                # get set of data in these successors
+                succs = ((node[0]+1, 2*node[1]), (node[0]+1, 2*node[1]+1))
+                sigma_T = data_at_node(succs[0])
+                sigma_F = data_at_node(succs[1])                
+                
+                #keep tabs on how training is going
+                # if node[0] > self.current_max_depth:
+                    # self.current_max_depth = node[0]
+                    # if self.current_max_depth % 30 == 0:
+                    #     if self.current_max_depth > 1:
+                    #         print('current max depth', self.current_max_depth)
+                # print('current max depth', self.current_max_depth)
+                
+                # construct_subtree on the sucessors
+                construct_subtree(succs[0], sigma_T)
+                construct_subtree(succs[1], sigma_F)
+        
+        # train the dt 
+        construct_subtree((0,0), np.ones(n).astype(bool))
+        self.is_trained = True
+        return self
+    
+    
+    def predict(self, X):
+        """
+        Predict classes for examples in X.
+        The predicted class of an input sample is the majority vote by the trees in the forest.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The test samples.
+
+        Returns
+        -------
+        preds : array of shape (n_samples,)
+            The predicted classes.
+
+        """
+        # first check to see if the tree is empty/trained
+        if self.is_trained:
+            
+            preds = np.zeros(len(X)).astype(np.int8)
+            for i in range(len(X)):
+                X_ = X[i]
+                a,b = 0,0
+                tnode = self.nodes[(a,b)]
+                while not tnode['is_leaf']:
+                    check = X_[tnode['j']] <= tnode['xi']
+                    
+                    if check:
+                        b = 2*b
+                    else:
+                        b = 2*b + 1
+                        
+                    a += 1
+                    tnode = self.nodes[(a,b)]
+              
+                if tnode['is_leaf']:
+                    preds[i] = tnode['g']
+            
+            return preds
+        else:
+            print('tree not finished training!')
+    
+    def predict_proba(self, X):
+        """Predict class probabilities for examples in X."""
+        if not self.is_trained:
+            raise ValueError("Tree must be trained before predicting probabilities")
+        
+        predictions = self.predict(X)
+        # Convert {-1, 1} predictions to probabilities
+        # -1 -> probability 0 for positive class
+        # +1 -> probability 1 for positive class
+        probabilities = (predictions + 1) / 2
+        return probabilities
+    
+    def n_leaves(self):
+        """
+        Get the number of leaf nodes in a tree (number of regions created in feature space).
+
+        Returns
+        -------
+        temp : int
+            Number of leaf nodes in the classifier.
+
+        """
+        return self.leaf_count
+
+    def get_depth(self):
+        """
+        Return the depth of the decision tree. The depth of a tree is the maximum distance between the root and any leaf.
+
+        Returns
+        -------
+        max_depth : int
+            The maximum depth of the tree.
+
+        """
+
+        max_depth = -1
+        for node in self.nodes.keys():
+            if node[0] > max_depth:
+                max_depth = node[0]
+        return max_depth
+    
+    def feature_importances(self):
+        """
+        Compute the risk reduction feature importances.
+
+        Returns
+        -------
+        impurities : array-like of shape (n_features,)
+            Risk reduction feature importances.
+
+        """
+        
+        impurities = np.zeros([self.d])
+        for node in self.nodes:
+            if self.nodes[node]['j'] is not None:
+                impurities[self.nodes[node]['j']] += self.nodes[node]['risk_reduction']
+        
+        return impurities

--- a/reVeal/pu/trees.py
+++ b/reVeal/pu/trees.py
@@ -1,0 +1,463 @@
+# PU ExtraTrees - A Random Forest Classifier for PU Learning
+# Adapted from https://github.com/jonathanwilton/PUExtraTrees
+from .tree import PUExtraTree
+from joblib import Parallel, delayed
+import scipy
+import numpy as np
+
+class PUExtraTrees:
+    def __init__(self, n_estimators = 100,
+                 risk_estimator = 'nnPU',
+                 loss = 'quadratic',
+                 max_depth = None,
+                 min_samples_leaf = 1,
+                 max_features = 'sqrt',
+                 max_candidates = 1,
+                 n_jobs = 1,
+                 random_state = 42):
+        """
+        An extra-trees binary classifier that can be trained using only positive and unlabeled samples, or positive and negative samples.
+        
+        Parameters
+        ----------
+        random_state : int, default=42
+            Controls the randomness of the estimator for reproducible results.
+        risk_estimator : {"PN", "uPU", "nnPU"}, default='nnPU'
+            PU data based risk estimator. Supports supervised (PN) learning, unbiased PU (uPU) learning and nonnegative PU (nnPU) learning.
+        loss : {"quadratic", "logistic"}, default='quadratic'
+            The function to measure the cost of making an incorrect prediction. Supported loss functions are:
+            "quadratic" l(v,y) = (1-vy)^2 and 
+            "logistic" l(v,y) = ln(1+exp(-vy)).
+        max_depth : int or None, default=None
+            The maximum depth of the tree. If None, then nodes are expanded until all leaves are pure or until all leaves contain less than min_samples_leaf samples. 
+        min_samples_leaf : int, default=1
+            The minimum number of samples required to be at a leaf node. The default is 1.
+        max_features : int or {"sqrt", "all"}, default="sqrt"
+            The number of features to consider when looking for the best split. If "sqrt", then max_features = ceil(sqrt(n_features)). If "all", then max_features = n_features. 
+        max_candidates : int, default=1
+            Number of randomly chosen split points to consider for each candidate feature. 
+        n_jobs : int, default=1
+            The number of jobs to run in parallel. fit and predict are all parallelized over the trees.
+         
+        Returns
+        -------
+        None.
+
+        """
+        
+        self.n_estimators = n_estimators
+        self.risk_estimator = risk_estimator
+        self.loss = loss
+        self.max_depth = max_depth
+        self.min_samples_leaf = min_samples_leaf
+        self.max_features = max_features
+        self.max_candidates = max_candidates
+        self.n_jobs = n_jobs
+        self.random_state = random_state
+        
+        self.leaf_count = 0
+        self.current_max_depth = 0
+        self.is_trained = False # indicate if tree empty/trained
+    
+    def get_params(self, deep=True):
+        """
+        Get parameters for this estimator.
+        
+        Parameters
+        ----------
+        deep : bool, default=True
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+        
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+        """
+        return {
+            'n_estimators': self.n_estimators,
+            'risk_estimator': self.risk_estimator,
+            'loss': self.loss,
+            'max_depth': self.max_depth,
+            'min_samples_leaf': self.min_samples_leaf,
+            'max_features': self.max_features,
+            'max_candidates': self.max_candidates,
+            'n_jobs': self.n_jobs,
+            'random_state': self.random_state
+        }
+    
+    def set_params(self, **params):
+        """
+        Set the parameters of this estimator.
+        
+        Parameters
+        ----------
+        **params : dict
+            Estimator parameters.
+        
+        Returns
+        -------
+        self : object
+            Estimator instance.
+        """
+        for key, value in params.items():
+            setattr(self, key, value)
+        return self
+    
+    def train_tree(self, tree_idx, P = None, U = None, N = None, pi = None):
+        """
+        Train a single decision tree.
+
+        Parameters
+        ----------
+        tree_idx : int
+            Index of the tree being trained (for deterministic seeding)
+        P : array-like of shape (n_p, n_features), default=None
+            Training samples from the positive class. 
+        U : array-like of shape (n_u, n_features), default=None
+            Unlabelled training samples.
+        N : array-like of shape (n_n, n_features), default=None
+            Training samples from the negative class if performing supervised (PN) learning.
+        pi : float
+            Prior probability that an example belongs to the positive class.
+
+        Returns
+        -------
+        g : ET classifier
+            An instance of the single tree RF classifier.
+
+        """
+        # Create deterministic seed for this specific tree
+        tree_seed = self.random_state + tree_idx if self.random_state is not None else None
+        
+        g = PUExtraTree(risk_estimator = self.risk_estimator,
+                        loss = self.loss,
+                        max_depth = self.max_depth, 
+                        min_samples_leaf = self.min_samples_leaf, 
+                        max_features = self.max_features, 
+                        max_candidates = self.max_candidates,
+                        random_state = tree_seed)
+        g.fit(P = P, U = U, N = N, pi = pi)
+        return g
+    
+    def predict_tree(self, g, X):
+        """
+        Predict classes for examples in X using the single DT g.
+        
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The test samples.
+
+        Returns
+        -------
+        preds : array of shape (n_samples,)
+            The predicted classes.
+
+        """
+        return g.predict(X)
+    
+    def fit(self, P = None, U = None, N = None, pi = None):
+        """
+        Train the random forest.
+
+        Parameters
+        ----------
+        pi : float
+            Prior probability that an example belongs to the positive class. 
+        P : array-like of shape (n_p, n_features), default=None
+            Training samples from the positive class.
+        U : array-like of shape (n_u, n_features), default=None
+            Unlabeled training samples.
+        N : array-like of shape (n_n, n_features), default=None
+            Training samples from the negative class if performing PN learning.
+
+        Returns
+        -------
+        self
+            Returns instance of self.
+
+        """
+        # Use sequential processing for determinism when n_jobs=1
+        if self.n_jobs == 1:
+            self.gs = []
+            for i in range(self.n_estimators):
+                tree = self.train_tree(tree_idx=i, P=P, U=U, N=N, pi=pi)
+                self.gs.append(tree)
+        else:
+            # For parallel processing, pass tree indices for deterministic seeding
+            self.gs = Parallel(n_jobs = min(self.n_jobs, self.n_estimators), prefer="threads")(
+                delayed(self.train_tree)(tree_idx=i, P=P, U=U, N=N, pi=pi) 
+                for i in range(self.n_estimators)
+            )
+        
+        self.is_trained = True
+        return self
+    
+    def predict(self, X):
+        """
+        Predict classes for examples in X.
+        The predicted class of an input sample is the majority vote by the trees in the forest.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The test samples.
+
+        Returns
+        -------
+        preds : array of shape (n_samples,)
+            The predicted classes.
+
+        """
+        # Use sequential processing for determinism when n_jobs=1
+        if self.n_jobs == 1:
+            preds = []
+            for g in self.gs:
+                preds.append(self.predict_tree(g, X))
+            self.preds = preds
+        else:
+            self.preds = Parallel(n_jobs = min(self.n_jobs, self.n_estimators), prefer="threads")(
+                delayed(self.predict_tree)(g, X) for g in self.gs
+            )
+        
+        return scipy.stats.mode(np.array(self.preds), axis = 0, keepdims = False)[0]
+    
+    def predict_proba(self, X):
+        """
+        Predict class probabilities for examples in X.
+        The predicted class probabilities of an input sample is the mean predicted class probabilities by the trees in the forest.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The test samples.
+
+        Returns
+        -------
+        proba : array of shape (n_samples, 2)
+            The class probabilities of the input samples. proba[i, j] is the probability that sample i belongs to class j.
+
+        """
+        # Keep original logic - using sequential processing for determinism when n_jobs=1
+        if self.n_jobs == 1:
+            preds = []
+            for g in self.gs:
+                preds.append(self.predict_tree(g, X))
+            self.preds = preds
+        else:
+            self.preds = Parallel(n_jobs = min(self.n_jobs, self.n_estimators), prefer="threads")(
+                delayed(self.predict_tree)(g, X) for g in self.gs
+            )
+        
+        preds_array = np.array(self.preds)
+        preds_array[preds_array < 1] = 0
+        return np.mean(preds_array, axis = 0)
+
+    def n_leaves(self, tree):
+        """
+        Get the number of leaf nodes in a specified tree
+
+        Parameters
+        ----------
+        tree : int
+            The index of the tree.
+
+        Returns
+        -------
+        Number of leaf nodes in the specified tree.
+
+        """
+        
+        return self.gs[tree].n_leaves()
+    
+    def get_depth(self, tree):
+        """
+        Get the depth of a specified tree in the forest.
+
+        Parameters
+        ----------
+        tree : int
+            The index of the tree.
+
+        Returns
+        -------
+        Depth of the specified tree.
+
+        """
+        
+        return self.gs[tree].get_depth()
+    
+    def get_max_depth(self):
+        """
+        Return the depth of the deepest tree in the forest.
+
+        Returns
+        -------
+        Maximum depth : int
+
+        """
+        
+        depths = []
+        for tree in self.gs:
+            depths += [tree.get_depth()]
+        return np.max(depths)
+    
+    def feature_importances(self):
+        """
+        Get the risk reduction feature importances.
+
+        Returns
+        -------
+        importances : array of shape (n_features,)
+            The risk reduction feature importances.
+
+        """
+        importances = np.zeros([self.gs[0].d])
+        for tree in self.gs:
+            importances += tree.feature_importances()/self.n_estimators
+        
+        return importances
+
+    def extract_cutpoints(self, feature_idx):
+        """
+        Extract all cutpoints (split thresholds) for a specific feature across all trees in the forest.
+        
+        Parameters
+        ----------
+        feature_idx : int
+            Index of the feature to extract cutpoints for.
+        
+        Returns
+        -------
+        cutpoints : np.ndarray
+            Sorted array of unique cutpoints for the specified feature.
+        """
+        cutpoints = []
+        
+        # Iterate through all trees in the forest
+        for tree in self.gs:
+            # Iterate through all nodes in the tree
+            for node_key, node_data in tree.nodes.items():
+                # Check if this node splits on the feature of interest
+                if node_data['j'] == feature_idx and node_data['xi'] is not None:
+                    cutpoints.append(node_data['xi'])
+        
+        # Return sorted unique cutpoints
+        if len(cutpoints) == 0:
+            return np.array([])
+        
+        return np.unique(cutpoints)
+
+
+    def create_grid(self, X, conditioning_features):
+        """
+        Create a grid that partitions the feature space based on cutpoints from the trees.
+        
+        The grid divides each conditioning feature's range into intervals defined by
+        the split points (cutpoints) that the trees use for that feature.
+        
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            Data to create grid for (typically test set).
+        conditioning_features : list of int
+            Indices of features to condition on (the Z variables).
+        
+        Returns
+        -------
+        grid : dict
+            Dictionary mapping feature indices to their grid boundaries.
+            grid[feature_idx] = array of boundaries defining intervals
+        """
+        if not self.is_trained:
+            raise ValueError("Forest must be trained before creating grid")
+        
+        grid = {}
+        
+        for feature_idx in conditioning_features:
+            # Extract cutpoints from trees
+            cutpoints = self.extract_cutpoints(feature_idx)
+            
+            # Get min and max values from the data
+            feature_min = X[:, feature_idx].min()
+            feature_max = X[:, feature_idx].max()
+            
+            # Create grid boundaries: [min, cutpoint1, cutpoint2, ..., max]
+            # Only include cutpoints that fall within the data range
+            valid_cutpoints = cutpoints[(cutpoints > feature_min) & (cutpoints < feature_max)]
+            
+            # Combine min, cutpoints, and max to form complete boundaries
+            boundaries = np.concatenate([[feature_min], valid_cutpoints, [feature_max]])
+            boundaries = np.unique(boundaries)  # Ensure uniqueness and sort
+            
+            grid[feature_idx] = boundaries
+        
+        return grid
+
+
+    def assign_to_grid_cells(self, X, grid):
+        """
+        Assign each sample in X to a grid cell based on the grid boundaries.
+        
+        For each conditioning feature, determines which interval the sample falls into.
+        The combination of intervals across all conditioning features defines the grid cell.
+        
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            Data to assign to grid cells.
+        grid : dict
+            Grid boundaries from create_grid().
+        
+        Returns
+        -------
+        grid_cells : np.ndarray of shape (n_samples, n_conditioning_features)
+            Grid cell indices for each sample. grid_cells[i, j] indicates which
+            interval sample i falls into for conditioning feature j.
+        """
+        n_samples = X.shape[0]
+        n_conditioning = len(grid)
+        
+        # Initialize array to store grid cell assignments
+        grid_cells = np.zeros((n_samples, n_conditioning), dtype=np.int32)
+        
+        # For each conditioning feature
+        for idx, (feature_idx, boundaries) in enumerate(grid.items()):
+            # Use searchsorted to find which interval each sample falls into
+            # searchsorted returns the index where value would be inserted
+            # This gives us the interval: [boundaries[i-1], boundaries[i]]
+            feature_values = X[:, feature_idx]
+            cell_indices = np.searchsorted(boundaries, feature_values, side='right') - 1
+            
+            # Ensure indices are within bounds (handles edge cases)
+            cell_indices = np.clip(cell_indices, 0, len(boundaries) - 2)
+            
+            grid_cells[:, idx] = cell_indices
+        
+        return grid_cells
+
+
+    def get_samples_in_cell(self, grid_cells, target_cell):
+        """
+        Get indices of samples that belong to a specific grid cell.
+        
+        Parameters
+        ----------
+        grid_cells : np.ndarray of shape (n_samples, n_conditioning_features)
+            Grid cell assignments from assign_to_grid_cells().
+        target_cell : tuple or np.ndarray
+            The grid cell to find samples for. Length must match n_conditioning_features.
+        
+        Returns
+        -------
+        sample_indices : np.ndarray
+            Indices of samples in the target grid cell.
+        """
+        # Convert target_cell to array if it's a tuple
+        target_cell = np.array(target_cell)
+        
+        # Find samples where all conditioning features match the target cell
+        matches = np.all(grid_cells == target_cell, axis=1)
+        
+        return np.where(matches)[0]

--- a/tests/test_learn_weights.py
+++ b/tests/test_learn_weights.py
@@ -1,0 +1,316 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for learn_weights module.
+"""
+import json
+import numpy as np
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point, box
+
+from reVeal.learn_weights import (
+    prepare_pu_data,
+    train_pu_model,
+    tune_class_prior,
+    importances_to_weights,
+    generate_score_weighted_config,
+)
+
+
+@pytest.fixture
+def synthetic_grid():
+    """Create a synthetic grid with score columns for testing."""
+    rng = np.random.default_rng(42)
+    n_cells = 200
+
+    # Create a grid of square polygons
+    geoms = [box(i % 20, i // 20, (i % 20) + 1, (i // 20) + 1) for i in range(n_cells)]
+
+    data = {
+        "gid": list(range(n_cells)),
+        "feature_a_score": rng.uniform(0, 1, n_cells),
+        "feature_b_score": rng.uniform(0, 1, n_cells),
+        "feature_c_score": rng.uniform(0, 1, n_cells),
+        "geometry": geoms,
+    }
+
+    # Make feature_a strongly correlated with being "positive" for cells 0-19
+    data["feature_a_score"][:20] = rng.uniform(0.7, 1.0, 20)
+    data["feature_a_score"][20:] = rng.uniform(0.0, 0.4, 180)
+
+    return gpd.GeoDataFrame(data, crs="EPSG:4326")
+
+
+@pytest.fixture
+def synthetic_labels():
+    """Create point labels that fall within the first 20 grid cells."""
+    # Points in centers of grid cells 0-19 (which are at x=0..19, y=0)
+    points = [Point(i + 0.5, 0.5) for i in range(20)]
+    return gpd.GeoDataFrame({"id": range(20), "geometry": points}, crs="EPSG:4326")
+
+
+class TestPrepareData:
+    """Tests for prepare_pu_data."""
+
+    def test_basic_splits(self, synthetic_grid, synthetic_labels):
+        """Test that data splits are created with correct sizes."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            attributes=attributes,
+            background_samples=50,
+            test_size=0.2,
+            validation_size=0.1,
+            random_state=42,
+        )
+
+        assert "train_gids" in splits
+        assert "test_gids" in splits
+        assert "validation_gids" in splits
+        assert "background_gids" in splits
+        assert len(splits["train_gids"]) > 0
+        assert len(splits["background_gids"]) > 0
+
+        # No overlap between train and test
+        assert not set(splits["train_gids"]) & set(splits["test_gids"])
+
+    def test_background_size_capped(self, synthetic_grid, synthetic_labels):
+        """Test that background sampling respects available cells."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            attributes=attributes,
+            background_samples=1000,  # More than available
+            random_state=42,
+        )
+        # Should be capped at non-intersecting count (180)
+        assert len(splits["background_gids"]) <= 180
+
+
+class TestTrainModel:
+    """Tests for train_pu_model."""
+
+    def test_train_produces_importances(self, synthetic_grid, synthetic_labels):
+        """Test that training produces feature importances."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            attributes=attributes,
+            background_samples=50,
+            random_state=42,
+        )
+
+        results = train_pu_model(
+            grid_df=synthetic_grid,
+            data_splits=splits,
+            attributes=attributes,
+            n_estimators=10,  # Small for speed
+            random_state=42,
+        )
+
+        assert "feature_importances" in results
+        assert len(results["feature_importances"]) == 3
+        assert results["model"] is not None
+
+
+class TestImportancesToWeights:
+    """Tests for importances_to_weights."""
+
+    def test_normalization(self):
+        """Test that weights sum to 1."""
+        importances = np.array([0.5, 0.3, 0.2])
+        attrs = ["a_score", "b_score", "c_score"]
+        weights = importances_to_weights(importances, attrs)
+
+        total = sum(w["weight"] for w in weights)
+        assert abs(total - 1.0) < 1e-10
+
+    def test_excludes_zero_importances(self):
+        """Test that features with 0 importance are excluded."""
+        importances = np.array([0.5, 0.0, 0.3])
+        attrs = ["a_score", "b_score", "c_score"]
+        weights = importances_to_weights(importances, attrs)
+
+        assert len(weights) == 2
+        attr_names = [w["attribute"] for w in weights]
+        assert "b_score" not in attr_names
+
+    def test_excludes_negative_importances(self):
+        """Test that features with negative importance are excluded."""
+        importances = np.array([0.5, -0.1, 0.3])
+        attrs = ["a_score", "b_score", "c_score"]
+        weights = importances_to_weights(importances, attrs)
+
+        assert len(weights) == 2
+        total = sum(w["weight"] for w in weights)
+        assert abs(total - 1.0) < 1e-10
+
+    def test_all_zero_raises(self):
+        """Test that all-zero importances raises ValueError."""
+        importances = np.array([0.0, 0.0, 0.0])
+        attrs = ["a_score", "b_score", "c_score"]
+        with pytest.raises(ValueError, match="All feature importances"):
+            importances_to_weights(importances, attrs)
+
+    def test_sorted_descending(self):
+        """Test that output is sorted by weight descending."""
+        importances = np.array([0.1, 0.5, 0.3])
+        attrs = ["a_score", "b_score", "c_score"]
+        weights = importances_to_weights(importances, attrs)
+
+        weight_values = [w["weight"] for w in weights]
+        assert weight_values == sorted(weight_values, reverse=True)
+
+
+class TestGenerateConfig:
+    """Tests for generate_score_weighted_config."""
+
+    def test_config_format(self):
+        """Test that generated config matches expected schema."""
+        weights = [
+            {"attribute": "fiber_score", "weight": 0.6},
+            {"attribute": "tline_score", "weight": 0.4},
+        ]
+        config = generate_score_weighted_config(
+            weights, "/path/to/grid.gpkg", "my_score"
+        )
+
+        assert config["grid"] == "/path/to/grid.gpkg"
+        assert config["score_name"] == "my_score"
+        assert len(config["attributes"]) == 2
+        assert config["attributes"][0]["attribute"] == "fiber_score"
+        assert config["attributes"][0]["weight"] == 0.6
+
+
+class TestEndToEnd:
+    """End-to-end integration test."""
+
+    def test_full_pipeline(self, synthetic_grid, synthetic_labels):
+        """Test full pipeline produces valid score-weighted config."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            attributes=attributes,
+            background_samples=50,
+            random_state=42,
+        )
+
+        results = train_pu_model(
+            grid_df=synthetic_grid,
+            data_splits=splits,
+            attributes=attributes,
+            n_estimators=10,
+            random_state=42,
+        )
+
+        weights = importances_to_weights(results["feature_importances"], attributes)
+        config = generate_score_weighted_config(weights, "grid_normalized.gpkg")
+
+        # Validate output structure
+        assert "attributes" in config
+        assert "score_name" in config
+        assert len(config["attributes"]) > 0
+
+        # Validate weights sum to 1
+        total = sum(a["weight"] for a in config["attributes"])
+        assert abs(total - 1.0) < 1e-10
+
+        # All weights in valid range
+        for attr in config["attributes"]:
+            assert attr["weight"] > 0
+            assert attr["weight"] <= 1
+
+
+class TestTuneClassPrior:
+    """Tests for tune_class_prior (Optuna-based tuning)."""
+
+    def test_returns_best_prior(self, synthetic_grid, synthetic_labels):
+        """Test that tuning returns a valid class_prior."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            attributes=attributes,
+            background_samples=50,
+            random_state=42,
+        )
+
+        result = tune_class_prior(
+            grid_df=synthetic_grid,
+            data_splits=splits,
+            attributes=attributes,
+            n_estimators=10,
+            n_jobs=1,
+            random_state=42,
+            n_trials=5,
+            metric="auc",
+        )
+
+        assert "best_class_prior" in result
+        assert "best_value" in result
+        assert 0.01 <= result["best_class_prior"] <= 0.99
+        assert 0.0 <= result["best_value"] <= 1.0
+
+    def test_tpr_metric(self, synthetic_grid, synthetic_labels):
+        """Test tuning with TPR metric."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            attributes=attributes,
+            background_samples=50,
+            random_state=42,
+        )
+
+        result = tune_class_prior(
+            grid_df=synthetic_grid,
+            data_splits=splits,
+            attributes=attributes,
+            n_estimators=10,
+            n_jobs=1,
+            random_state=42,
+            n_trials=5,
+            metric="tpr",
+        )
+
+        assert 0.01 <= result["best_class_prior"] <= 0.99
+
+    def test_tuned_prior_used_in_training(self, synthetic_grid, synthetic_labels):
+        """Test that tuned prior can be used to train a final model."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            attributes=attributes,
+            background_samples=50,
+            random_state=42,
+        )
+
+        tuning_result = tune_class_prior(
+            grid_df=synthetic_grid,
+            data_splits=splits,
+            attributes=attributes,
+            n_estimators=10,
+            n_jobs=1,
+            random_state=42,
+            n_trials=5,
+            metric="auc",
+        )
+
+        # Use tuned prior to train final model
+        results = train_pu_model(
+            grid_df=synthetic_grid,
+            data_splits=splits,
+            attributes=attributes,
+            n_estimators=10,
+            class_prior=tuning_result["best_class_prior"],
+            random_state=42,
+        )
+
+        assert results["model"] is not None
+        assert len(results["feature_importances"]) == 3

--- a/tests/test_learn_weights.py
+++ b/tests/test_learn_weights.py
@@ -2,7 +2,6 @@
 """
 Tests for learn_weights module.
 """
-import json
 import numpy as np
 import geopandas as gpd
 import pytest
@@ -54,11 +53,9 @@ class TestPrepareData:
 
     def test_basic_splits(self, synthetic_grid, synthetic_labels):
         """Test that data splits are created with correct sizes."""
-        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
         splits = prepare_pu_data(
             grid_df=synthetic_grid,
             labels_gdf=synthetic_labels,
-            attributes=attributes,
             background_samples=50,
             test_size=0.2,
             validation_size=0.1,
@@ -77,11 +74,9 @@ class TestPrepareData:
 
     def test_background_size_capped(self, synthetic_grid, synthetic_labels):
         """Test that background sampling respects available cells."""
-        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
         splits = prepare_pu_data(
             grid_df=synthetic_grid,
             labels_gdf=synthetic_labels,
-            attributes=attributes,
             background_samples=1000,  # More than available
             random_state=42,
         )
@@ -98,7 +93,6 @@ class TestTrainModel:
         splits = prepare_pu_data(
             grid_df=synthetic_grid,
             labels_gdf=synthetic_labels,
-            attributes=attributes,
             background_samples=50,
             random_state=42,
         )
@@ -114,6 +108,65 @@ class TestTrainModel:
         assert "feature_importances" in results
         assert len(results["feature_importances"]) == 3
         assert results["model"] is not None
+
+    def test_empty_positives_raises(self, synthetic_grid):
+        """Test that empty positive training set raises ValueError."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+        splits = {
+            "train_gids": np.array([]),
+            "validation_gids": np.array([]),
+            "test_gids": np.array([]),
+            "background_gids": np.array([0, 1, 2, 3, 4]),
+            "background_test_gids": np.array([]),
+            "background_val_gids": np.array([]),
+        }
+        with pytest.raises(ValueError, match="No positive training samples"):
+            train_pu_model(
+                grid_df=synthetic_grid,
+                data_splits=splits,
+                attributes=attributes,
+                n_estimators=10,
+                random_state=42,
+            )
+
+    def test_empty_background_raises(self, synthetic_grid):
+        """Test that empty background training set raises ValueError."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+        splits = {
+            "train_gids": np.array([0, 1, 2, 3, 4]),
+            "validation_gids": np.array([]),
+            "test_gids": np.array([]),
+            "background_gids": np.array([]),
+            "background_test_gids": np.array([]),
+            "background_val_gids": np.array([]),
+        }
+        with pytest.raises(ValueError, match="No background"):
+            train_pu_model(
+                grid_df=synthetic_grid,
+                data_splits=splits,
+                attributes=attributes,
+                n_estimators=10,
+                random_state=42,
+            )
+
+    def test_invalid_class_prior_raises(self, synthetic_grid, synthetic_labels):
+        """Test that class_prior outside (0,1) raises ValueError."""
+        attributes = ["feature_a_score", "feature_b_score", "feature_c_score"]
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            background_samples=50,
+            random_state=42,
+        )
+        with pytest.raises(ValueError, match="class_prior must be between"):
+            train_pu_model(
+                grid_df=synthetic_grid,
+                data_splits=splits,
+                attributes=attributes,
+                n_estimators=10,
+                class_prior=1.0,
+                random_state=42,
+            )
 
 
 class TestImportancesToWeights:
@@ -195,7 +248,6 @@ class TestEndToEnd:
         splits = prepare_pu_data(
             grid_df=synthetic_grid,
             labels_gdf=synthetic_labels,
-            attributes=attributes,
             background_samples=50,
             random_state=42,
         )
@@ -235,7 +287,6 @@ class TestTuneClassPrior:
         splits = prepare_pu_data(
             grid_df=synthetic_grid,
             labels_gdf=synthetic_labels,
-            attributes=attributes,
             background_samples=50,
             random_state=42,
         )
@@ -262,7 +313,6 @@ class TestTuneClassPrior:
         splits = prepare_pu_data(
             grid_df=synthetic_grid,
             labels_gdf=synthetic_labels,
-            attributes=attributes,
             background_samples=50,
             random_state=42,
         )
@@ -286,7 +336,6 @@ class TestTuneClassPrior:
         splits = prepare_pu_data(
             grid_df=synthetic_grid,
             labels_gdf=synthetic_labels,
-            attributes=attributes,
             background_samples=50,
             random_state=42,
         )


### PR DESCRIPTION
Introduces a new `reVeal learn-weights` pipeline step that trains a PUExtraTrees model on a normalized grid using point labels as positive samples. Derives feature importance weights for use with `score-weighted`.

- Add reVeal/pu/ — PUExtraTree/PUExtraTrees adapted from https://github.com/jonathanwilton/PUExtraTrees, with modifications from /projects/largeload/.../models/PUExtraTrees/ (deterministic seeding, joblib parallelism)
- Add reVeal/learn_weights.py — data preparation logic adapted from /projects/largeload/.../models/prepare_data.py (DataHandler), training and metrics from /projects/largeload/.../models/models.py (ModelTrainer)
- Add Optuna-based hyperparameter tuning for class_prior — adapted from ModelTrainer.tune_hyperparameters() and ModelTrainer.objective() in /projects/largeload/.../models/models.py
- Add CLI command (reVeal/cli/learn_weights.py), config (reVeal/config/learn_weights.py), and tests — new code following existing reVeal CLI patterns (score_weighted, normalize)
- Add joblib, scipy, optuna to pyproject.toml and environment.yml

Tested by running the new CLI tool like so
```
python -m reVeal.cli.cli learn-weights -c /projects/largeload/geospatial/runs/test_scenarios/learned_weights_2026-05-19_agg64/config_learn_weights.json
```

You can use the learned_weights_2026-05-19_agg64/ directory to test this code.

Next Steps:
This works well to generate the score weights. However, in practice there many of these features are highly correlated or we want to manually exclude for other purposes. We want a few feature engineering tools that will allow users to iterate on the score outputs. This will include:
1. An exclude list
2. Visualization features (dendrogram and correlation matrix) to help users feature engineer before it goes into the score_weighted step.