### PR TITLE
Add feature analysis CLI and learn-weights enhancements

### DIFF
--- a/docs/source/_cli/cli.rst
+++ b/docs/source/_cli/cli.rst
@@ -10,6 +10,7 @@ Command Line Interfaces (CLIs)
    reVeal characterize
    reVeal normalize
    reVeal score-weighted
+   reVeal learn-weights
    reVeal analyze-features
    reVeal pipeline
    reVeal batch

--- a/docs/source/_cli/cli.rst
+++ b/docs/source/_cli/cli.rst
@@ -10,6 +10,7 @@ Command Line Interfaces (CLIs)
    reVeal characterize
    reVeal normalize
    reVeal score-weighted
+   reVeal analyze-features
    reVeal pipeline
    reVeal batch
    reVeal script

--- a/docs/source/_cli/reVeal analyze-features.rst
+++ b/docs/source/_cli/reVeal analyze-features.rst
@@ -1,0 +1,3 @@
+.. click:: reVeal.cli.analyze_features:main
+   :prog: reVeal analyze-features
+   :nested: full

--- a/docs/source/_cli/reVeal learn-weights.rst
+++ b/docs/source/_cli/reVeal learn-weights.rst
@@ -1,0 +1,3 @@
+.. click:: reVeal.cli.learn_weights:main
+   :prog: reVeal learn-weights
+   :nested: full

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
     - scipy>=1.14.0,<2
     - tqdm>=4.67.1,<5
     - exactextract>=0.2.2,<1
+    - matplotlib>=3.8.0,<4
     - optuna>=4.0.0,<5
     - pydantic>=2.12.5,<3
     - libpysal>=4.13.0,<5

--- a/pixi.lock
+++ b/pixi.lock
@@ -17034,14 +17034,15 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: nlr-reveal
-  version: 0.2.4.dev15+ga602ddc77
-  sha256: 5bff02f6a695cd91e0a3e10d6bb66a975ebd79a5dd7bb275d5d593b2e7949312
+  version: 0.2.4.dev17+g4c5ace714.d20260528
+  sha256: 67f2f8780ec785d0dc69719d558eeef872ef428a89c5ba138be2e79d02bab7c6
   requires_dist:
   - exactextract>=0.3.0,<0.4
   - geopandas>=1.1.1,<2
   - gdal>=3.10.3,<4
   - joblib>=1.4.0,<2
   - libpysal>=4.13.0,<5
+  - matplotlib>=3.8.0,<4
   - nlr-gaps>=0.9.1,<1
   - nlr-rex>=0.5.0,<1
   - optuna>=4.0.0,<5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "gdal>=3.10.3,<4",
   "joblib>=1.4.0,<2",
   "libpysal>=4.13.0,<5",
+  "matplotlib>=3.8.0,<4",
   "NLR-GAPs>=0.9.1,<1",
   "NLR-rex>=0.5.0,<1",
   "optuna>=4.0.0,<5",

--- a/reVeal/cli/analyze_features.py
+++ b/reVeal/cli/analyze_features.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+"""
+cli.analyze_features module - Sets up analyze-features command for use with
+NLR-GAPs CLI.
+"""
+import json
+import logging
+from pathlib import Path
+
+import geopandas as gpd
+from pydantic import ValidationError
+from gaps.cli import as_click_command, CLICommandFromFunction
+
+from reVeal.config.analyze_features import AnalyzeFeaturesConfig
+from reVeal.feature_analysis import (
+    compute_correlation_matrix,
+    compute_feature_clusters,
+    save_analysis_outputs,
+    suggest_exclusions,
+)
+from reVeal.log import get_logger, remove_streamhandlers
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _log_inputs(config):
+    """
+    Emit log messages summarizing user inputs.
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary.
+    """
+    LOGGER.info(f"Inputs config: {json.dumps(config, indent=4, default=str)}")
+
+
+def _preprocessor(config, job_name, log_directory, verbose):
+    """
+    Preprocess user-input configuration.
+
+    Parameters
+    ----------
+    config : dict
+        User configuration file input as (nested) dict.
+    job_name : str
+        Name of job being run.
+    log_directory : Path
+        Path to log directory.
+    verbose : bool
+        Flag to signal DEBUG verbosity.
+
+    Returns
+    -------
+    dict
+        Configuration dictionary modified to include additional parameters.
+    """
+    if verbose:
+        log_level = "DEBUG"
+    else:
+        log_level = "INFO"
+    get_logger(
+        __name__, log_level=log_level, out_path=log_directory / f"{job_name}.log"
+    )
+
+    LOGGER.info("Validating input configuration file")
+    try:
+        af_config = {
+            k: config.get(k)
+            for k in AnalyzeFeaturesConfig.model_fields.keys()
+            if k in config
+        }
+        AnalyzeFeaturesConfig(**af_config)
+    except ValidationError as e:
+        LOGGER.error(
+            "Configuration did not pass validation. "
+            f"The following issues were identified:\n{e}"
+        )
+        raise e
+    LOGGER.info("Input configuration file is valid.")
+
+    config["_local"] = (
+        config.get("execution_control", {}).get("option", "local") == "local"
+    )
+    _log_inputs(config)
+
+    return config
+
+
+def run(
+    grid,
+    out_dir,
+    attributes=None,
+    exclude_attributes=None,
+    correlation_method="spearman",
+    cluster_threshold=0.7,
+    _local=True,
+):
+    """
+    Analyze feature correlations and clusters in a normalized grid.
+
+    Computes a correlation matrix, performs hierarchical clustering, generates
+    dendrogram and heatmap plots, and suggests redundant features for exclusion.
+
+    Parameters
+    ----------
+    grid : str
+        Path to the normalized grid (output of ``reVeal normalize``). Must be a
+        vector dataset readable by pyogrio with numeric ``*_score`` columns.
+    out_dir : str
+        Output directory. Analysis artifacts will be saved to an ``analysis/``
+        subdirectory.
+    attributes : list of str, optional
+        List of column names from the grid to use as features. If not specified,
+        all columns ending with ``_score`` are used automatically.
+    exclude_attributes : list of str, optional
+        Score columns to exclude from auto-detected features. All ``*_score``
+        columns except those listed will be used. Mutually exclusive with
+        ``attributes``.
+    correlation_method : str, optional
+        Correlation method: 'spearman' or 'pearson'. Default is 'spearman'.
+    cluster_threshold : float, optional
+        Distance threshold for hierarchical clustering. Lower values produce
+        more clusters (features must be more similar to cluster together).
+        Default is 0.7.
+    _local : bool
+        Flag indicating local vs HPC execution. Not user-provided.
+    """
+    # pylint: disable=unused-argument
+
+    if _local:
+        remove_streamhandlers(LOGGER.parent)
+
+    def _progress(msg):
+        """Print progress to stdout and log."""
+        print(msg, flush=True)
+        LOGGER.info(msg)
+
+    config = AnalyzeFeaturesConfig(
+        grid=grid,
+        attributes=attributes,
+        exclude_attributes=exclude_attributes,
+        correlation_method=correlation_method,
+        cluster_threshold=cluster_threshold,
+    )
+
+    # Read grid
+    _progress(f"Reading grid from {config.grid}...")
+    grid_df = gpd.read_file(config.grid, engine="pyogrio", use_arrow=True)
+    grid_df.fillna(0, inplace=True)
+    _progress(f"Grid loaded: {len(grid_df):,} cells, {len(grid_df.columns)} columns.")
+
+    # Resolve attributes
+    if config.attributes is not None:
+        features = config.attributes
+    elif config.exclude_attributes is not None:
+        all_score_cols = [c for c in grid_df.columns if c.endswith("_score")]
+        exclude_set = set(config.exclude_attributes)
+        features = [c for c in all_score_cols if c not in exclude_set]
+        LOGGER.info(
+            f"Excluded {len(exclude_set)} attributes, "
+            f"using {len(features)} of {len(all_score_cols)} score columns."
+        )
+    else:
+        features = [c for c in grid_df.columns if c.endswith("_score")]
+        LOGGER.info(f"Auto-detected {len(features)} score attributes.")
+
+    if not features:
+        raise ValueError(
+            "No attributes found. Provide 'attributes' in the config or ensure "
+            "the grid has columns ending with '_score'."
+        )
+
+    _progress(
+        f"Starting feature analysis ({config.correlation_method} correlation, "
+        f"{len(features)} features, {len(grid_df):,} grid cells)..."
+    )
+
+    # Compute correlation matrix
+    X = grid_df[features].to_numpy()
+    _progress(
+        f"Computing {config.correlation_method} correlation matrix "
+        f"({len(grid_df):,} samples x {len(features)} features)... "
+        f"this may take a few minutes for large grids."
+    )
+    corr_matrix = compute_correlation_matrix(
+        X, features, method=config.correlation_method
+    )
+    _progress("Correlation matrix computed. Computing feature clusters...")
+
+    # Compute clusters
+    cluster_result = compute_feature_clusters(
+        corr_matrix, threshold=config.cluster_threshold
+    )
+    n_clusters = len(cluster_result["clusters"])
+    _progress(f"Feature analysis complete. Found {n_clusters} clusters.")
+
+    # Suggest exclusions
+    suggested = suggest_exclusions(
+        clusters=cluster_result["clusters"],
+        corr_matrix=corr_matrix,
+    )
+
+    # Save outputs
+    out_path = Path(out_dir)
+    analysis_dir = out_path / "analysis"
+    _progress(f"Saving analysis outputs to {analysis_dir}...")
+
+    save_analysis_outputs(
+        corr_matrix=corr_matrix,
+        cluster_result=cluster_result,
+        out_dir=analysis_dir,
+    )
+
+    exclusions_out = analysis_dir / "suggested_exclusions.json"
+    with open(exclusions_out, "w") as f:
+        json.dump(suggested, f, indent=2)
+
+    _progress(f"Analysis complete. Outputs saved to {analysis_dir}")
+
+
+analyze_features_cmd = CLICommandFromFunction(
+    function=run,
+    name="analyze-features",
+    add_collect=False,
+    config_preprocessor=_preprocessor,
+)
+
+main = as_click_command(analyze_features_cmd)
+
+
+if __name__ == "__main__":
+    try:
+        main(obj={})
+    except Exception:
+        LOGGER.exception("Error running reVeal analyze-features command.")
+        raise

--- a/reVeal/cli/analyze_features.py
+++ b/reVeal/cli/analyze_features.py
@@ -6,6 +6,7 @@ NLR-GAPs CLI.
 import json
 import logging
 from pathlib import Path
+from pathlib import Path
 
 import geopandas as gpd
 from pydantic import ValidationError
@@ -131,11 +132,6 @@ def run(
     if _local:
         remove_streamhandlers(LOGGER.parent)
 
-    def _progress(msg):
-        """Print progress to stdout and log."""
-        print(msg, flush=True)
-        LOGGER.info(msg)
-
     config = AnalyzeFeaturesConfig(
         grid=grid,
         attributes=attributes,
@@ -145,10 +141,10 @@ def run(
     )
 
     # Read grid
-    _progress(f"Reading grid from {config.grid}...")
+    LOGGER.info(f"Reading grid from {config.grid}...")
     grid_df = gpd.read_file(config.grid, engine="pyogrio", use_arrow=True)
     grid_df.fillna(0, inplace=True)
-    _progress(f"Grid loaded: {len(grid_df):,} cells, {len(grid_df.columns)} columns.")
+    LOGGER.info(f"Grid loaded: {len(grid_df):,} cells, {len(grid_df.columns)} columns.")
 
     # Resolve attributes
     if config.attributes is not None:
@@ -171,14 +167,14 @@ def run(
             "the grid has columns ending with '_score'."
         )
 
-    _progress(
+    LOGGER.info(
         f"Starting feature analysis ({config.correlation_method} correlation, "
         f"{len(features)} features, {len(grid_df):,} grid cells)..."
     )
 
     # Compute correlation matrix
     X = grid_df[features].to_numpy()
-    _progress(
+    LOGGER.info(
         f"Computing {config.correlation_method} correlation matrix "
         f"({len(grid_df):,} samples x {len(features)} features)... "
         f"this may take a few minutes for large grids."
@@ -186,14 +182,14 @@ def run(
     corr_matrix = compute_correlation_matrix(
         X, features, method=config.correlation_method
     )
-    _progress("Correlation matrix computed. Computing feature clusters...")
+    LOGGER.info("Correlation matrix computed. Computing feature clusters...")
 
     # Compute clusters
     cluster_result = compute_feature_clusters(
         corr_matrix, threshold=config.cluster_threshold
     )
     n_clusters = len(cluster_result["clusters"])
-    _progress(f"Feature analysis complete. Found {n_clusters} clusters.")
+    LOGGER.info(f"Feature analysis complete. Found {n_clusters} clusters.")
 
     # Suggest exclusions
     suggested = suggest_exclusions(
@@ -204,7 +200,7 @@ def run(
     # Save outputs
     out_path = Path(out_dir)
     analysis_dir = out_path / "analysis"
-    _progress(f"Saving analysis outputs to {analysis_dir}...")
+    LOGGER.info(f"Saving analysis outputs to {analysis_dir}...")
 
     save_analysis_outputs(
         corr_matrix=corr_matrix,
@@ -216,7 +212,7 @@ def run(
     with open(exclusions_out, "w") as f:
         json.dump(suggested, f, indent=2)
 
-    _progress(f"Analysis complete. Outputs saved to {analysis_dir}")
+    LOGGER.info(f"Analysis complete. Outputs saved to {analysis_dir}")
 
 
 analyze_features_cmd = CLICommandFromFunction(

--- a/reVeal/cli/cli.py
+++ b/reVeal/cli/cli.py
@@ -10,11 +10,12 @@ from reVeal.cli.normalize import normalize_cmd
 from reVeal.cli.score_weighted import score_weighted_cmd
 from reVeal.cli.downscale import downscale_cmd
 from reVeal.cli.learn_weights import learn_weights_cmd
+from reVeal.cli.analyze_features import analyze_features_cmd
 
 logger = logging.getLogger(__name__)
 
 commands = [characterize_cmd, normalize_cmd, score_weighted_cmd, downscale_cmd,
-            learn_weights_cmd]
+            learn_weights_cmd, analyze_features_cmd]
 main = make_cli(commands, info={"name": "reVeal", "version": __version__})
 
 # export GAPs commands to namespace for documentation

--- a/reVeal/cli/learn_weights.py
+++ b/reVeal/cli/learn_weights.py
@@ -83,6 +83,7 @@ def run(
     labels,
     out_dir,
     attributes=None,
+    exclude_attributes=None,
     n_estimators=500,
     class_prior=None,
     background_samples=10000,
@@ -120,6 +121,10 @@ def run(
     attributes : list of str, optional
         List of column names from the grid to use as features. If not specified,
         all columns ending with ``_score`` are used automatically.
+    exclude_attributes : list of str, optional
+        Score columns to exclude from auto-detected features. All ``*_score``
+        columns except those listed will be used. Mutually exclusive with
+        ``attributes``.
     n_estimators : int, optional
         Number of trees in the PUExtraTrees forest. Default is 500.
     class_prior : float, optional
@@ -157,10 +162,16 @@ def run(
     if _local:
         remove_streamhandlers(LOGGER.parent)
 
+    def _progress(msg):
+        """Print progress to stdout and log."""
+        print(msg, flush=True)
+        LOGGER.info(msg)
+
     config = LearnWeightsConfig(
         grid=grid,
         labels=labels,
         attributes=attributes,
+        exclude_attributes=exclude_attributes,
         n_estimators=n_estimators,
         class_prior=class_prior,
         background_samples=background_samples,
@@ -175,15 +186,15 @@ def run(
         tuning_metric=tuning_metric,
     )
 
-    LOGGER.info("Running learn-weights pipeline...")
-    results = run_learn_weights(config)
+    _progress("Running learn-weights pipeline...")
+    results = run_learn_weights(config, progress_callback=_progress)
 
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
 
     # Save score-weighted config
     config_out = out_path / "config_score_weighted.json"
-    LOGGER.info(f"Saving score-weighted config to {config_out}...")
+    _progress(f"Saving score-weighted config to {config_out}")
     with open(config_out, "w") as f:
         json.dump(results["config"], f, indent=2)
 

--- a/reVeal/cli/learn_weights.py
+++ b/reVeal/cli/learn_weights.py
@@ -162,11 +162,6 @@ def run(
     if _local:
         remove_streamhandlers(LOGGER.parent)
 
-    def _progress(msg):
-        """Print progress to stdout and log."""
-        print(msg, flush=True)
-        LOGGER.info(msg)
-
     config = LearnWeightsConfig(
         grid=grid,
         labels=labels,
@@ -186,15 +181,15 @@ def run(
         tuning_metric=tuning_metric,
     )
 
-    _progress("Running learn-weights pipeline...")
-    results = run_learn_weights(config, progress_callback=_progress)
+    LOGGER.info("Running learn-weights pipeline...")
+    results = run_learn_weights(config)
 
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
 
     # Save score-weighted config
     config_out = out_path / "config_score_weighted.json"
-    _progress(f"Saving score-weighted config to {config_out}")
+    LOGGER.info(f"Saving score-weighted config to {config_out}")
     with open(config_out, "w") as f:
         json.dump(results["config"], f, indent=2)
 

--- a/reVeal/config/analyze_features.py
+++ b/reVeal/config/analyze_features.py
@@ -1,0 +1,33 @@
+"""
+config.analyze_features module - Configuration for analyze-features command.
+"""
+from typing import List, Literal, Optional
+
+from pydantic import Field, model_validator
+from typing_extensions import Annotated
+
+from reVeal.config.config import BaseGridConfig
+
+
+class AnalyzeFeaturesConfig(BaseGridConfig):
+    """
+    Configuration for the analyze-features command.
+
+    Defines inputs for computing feature correlation analysis, hierarchical
+    clustering, and generating exclusion suggestions on a normalized grid.
+    """
+
+    attributes: Optional[List[str]] = None
+    exclude_attributes: Optional[List[str]] = None
+    correlation_method: Literal["spearman", "pearson"] = "spearman"
+    cluster_threshold: Annotated[float, Field(gt=0, le=2)] = 0.7
+
+    @model_validator(mode="after")
+    def _validate_attribute_options(self):
+        """Ensure at most one attribute selection method is specified."""
+        if self.attributes is not None and self.exclude_attributes is not None:
+            raise ValueError(
+                "Only one of 'attributes' or 'exclude_attributes' "
+                "can be specified."
+            )
+        return self

--- a/reVeal/config/learn_weights.py
+++ b/reVeal/config/learn_weights.py
@@ -3,7 +3,7 @@ config.learn_weights module - Configuration for learn-weights command.
 """
 from typing import List, Literal, Optional
 
-from pydantic import FilePath, Field
+from pydantic import FilePath, Field, model_validator
 from typing_extensions import Annotated
 
 from reVeal.config.config import BaseGridConfig
@@ -19,6 +19,7 @@ class LearnWeightsConfig(BaseGridConfig):
 
     labels: FilePath
     attributes: Optional[List[str]] = None
+    exclude_attributes: Optional[List[str]] = None
     n_estimators: Annotated[int, Field(ge=10, le=10000)] = 500
     class_prior: Optional[Annotated[float, Field(gt=0, lt=1)]] = None
     background_samples: Annotated[int, Field(ge=100)] = 10000
@@ -31,3 +32,15 @@ class LearnWeightsConfig(BaseGridConfig):
     tune: bool = False
     n_trials: Annotated[int, Field(ge=1, le=1000)] = 20
     tuning_metric: Literal["auc", "tpr"] = "auc"
+
+    @model_validator(mode="after")
+    def _validate_attribute_options(self):
+        """Ensure at most one attribute selection method is specified."""
+        if self.attributes is not None and self.exclude_attributes is not None:
+            raise ValueError(
+                "Only one of 'attributes' or 'exclude_attributes' "
+                "can be specified."
+            )
+        return self
+
+

--- a/reVeal/feature_analysis.py
+++ b/reVeal/feature_analysis.py
@@ -1,0 +1,322 @@
+"""
+feature_analysis module - Correlation analysis and feature clustering tools.
+
+Provides functions for computing correlation matrices, identifying feature
+clusters via hierarchical clustering, plotting dendrograms and heatmaps,
+and suggesting feature exclusions based on importance within clusters.
+"""
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy.cluster import hierarchy
+from scipy.spatial.distance import squareform
+from scipy.stats import spearmanr
+
+logger = logging.getLogger(__name__)
+
+
+def compute_correlation_matrix(X, columns, method="spearman"):
+    """
+    Compute a correlation matrix for the given feature array.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        2D array of shape (n_samples, n_features).
+    columns : list of str
+        Feature names corresponding to columns of X.
+    method : str
+        Correlation method: 'spearman' or 'pearson'.
+
+    Returns
+    -------
+    pd.DataFrame
+        Symmetric correlation matrix with feature names as index/columns.
+    """
+    df = pd.DataFrame(X, columns=columns)
+
+    # Drop constant columns (no variance)
+    nunique = df.nunique(dropna=True)
+    valid_cols = nunique[nunique > 1].index.tolist()
+    df = df[valid_cols].dropna(axis=1, how="all")
+
+    n_samples, n_features = df.shape
+
+    if n_features == 0:
+        raise ValueError(
+            "No non-constant features remain after dropping constant columns. "
+            "Cannot compute a correlation matrix."
+        )
+    if n_features == 1:
+        logger.info("Only 1 non-constant feature; returning trivial 1x1 correlation matrix.")
+        return pd.DataFrame(
+            [[1.0]], index=df.columns.tolist(), columns=df.columns.tolist()
+        )
+
+    logger.info(
+        f"Computing {method} correlation matrix for {n_features} features "
+        f"across {n_samples:,} samples... (this may take a few minutes for large grids)"
+    )
+
+    if method == "spearman":
+        corr = spearmanr(df).correlation
+        # spearmanr returns a scalar when exactly 2 features
+        if np.ndim(corr) == 0:
+            corr = np.array([[1.0, corr], [corr, 1.0]])
+    elif method == "pearson":
+        corr = df.corr(method="pearson").values
+    else:
+        raise ValueError(f"Unknown correlation method: {method}. Use 'spearman' or 'pearson'.")
+
+    logger.info("Correlation matrix computed. Post-processing...")
+
+    # Handle NaN and ensure symmetry
+    corr = np.nan_to_num(corr, nan=0.0)
+    corr = (corr + corr.T) / 2
+    np.fill_diagonal(corr, 1.0)
+
+    return pd.DataFrame(corr, index=df.columns.tolist(), columns=df.columns.tolist())
+
+
+def compute_feature_clusters(corr_matrix, threshold=0.7):
+    """
+    Identify clusters of correlated features using hierarchical clustering.
+
+    Parameters
+    ----------
+    corr_matrix : pd.DataFrame
+        Correlation matrix (output of compute_correlation_matrix).
+    threshold : float
+        Distance threshold for forming clusters. Lower values create more
+        clusters (features must be more similar to cluster together).
+
+    Returns
+    -------
+    dict
+        Dictionary with keys:
+        - 'clusters': dict mapping cluster IDs to lists of feature names
+        - 'linkage': ndarray, the Ward linkage matrix
+        - 'dendrogram': dict, the dendrogram result from scipy
+    """
+    corr = corr_matrix.values
+    features = corr_matrix.columns.tolist()
+
+    logger.info(f"Computing hierarchical clustering for {len(features)} features...")
+
+    # Convert correlation to distance
+    distance_matrix = 1 - np.abs(corr)
+    distance_matrix = (distance_matrix + distance_matrix.T) / 2
+    np.fill_diagonal(distance_matrix, 0.0)
+
+    # Ward hierarchical clustering
+    dist_linkage = hierarchy.ward(squareform(distance_matrix))
+
+    # Form flat clusters
+    cluster_labels = hierarchy.fcluster(dist_linkage, threshold, criterion="distance")
+
+    feature_clusters = {}
+    for idx, cluster_id in enumerate(cluster_labels):
+        cluster_key = f"cluster_{cluster_id}"
+        if cluster_key not in feature_clusters:
+            feature_clusters[cluster_key] = []
+        feature_clusters[cluster_key].append(features[idx])
+
+    logger.info(f"Identified {len(feature_clusters)} feature clusters at threshold={threshold}")
+
+    # Generate dendrogram data (without plotting)
+    dendro = hierarchy.dendrogram(dist_linkage, labels=features, no_plot=True)
+
+    return {
+        "clusters": feature_clusters,
+        "linkage": dist_linkage,
+        "dendrogram": dendro,
+    }
+
+
+def plot_dendrogram(corr_matrix, linkage, save_path):
+    """
+    Plot and save a hierarchical clustering dendrogram.
+
+    Parameters
+    ----------
+    corr_matrix : pd.DataFrame
+        Correlation matrix (for feature names).
+    linkage : np.ndarray
+        Ward linkage matrix from compute_feature_clusters.
+    save_path : str or Path
+        Path to save the PNG output.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    features = corr_matrix.columns.tolist()
+    fig, ax = plt.subplots(1, 1, figsize=(max(12, len(features) * 0.4), 8))
+
+    hierarchy.dendrogram(
+        linkage,
+        labels=features,
+        ax=ax,
+        leaf_rotation=90,
+        leaf_font_size=max(6, min(10, 200 // len(features))),
+    )
+    ax.set_title("Feature Clustering Dendrogram (Ward Linkage)", fontsize=14, pad=20)
+    ax.set_xlabel("Features", fontsize=12)
+    ax.set_ylabel("Distance (1 - |correlation|)", fontsize=12)
+
+    fig.tight_layout()
+    plt.savefig(save_path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Dendrogram saved to {save_path}")
+
+
+def plot_correlation_heatmap(corr_matrix, dendro_result, save_path):
+    """
+    Plot and save a clustered correlation heatmap.
+
+    Parameters
+    ----------
+    corr_matrix : pd.DataFrame
+        Correlation matrix.
+    dendro_result : dict
+        Dendrogram result from compute_feature_clusters (contains 'leaves' order).
+    save_path : str or Path
+        Path to save the PNG output.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    corr = corr_matrix.values
+    leaves = dendro_result["leaves"]
+    leaf_labels = [dendro_result["ivl"][i] for i in range(len(dendro_result["ivl"]))]
+
+    # Reorder correlation matrix by dendrogram leaf order
+    ordered_corr = corr[leaves, :][:, leaves]
+
+    n = len(leaf_labels)
+    fig, ax = plt.subplots(1, 1, figsize=(max(12, n * 0.35), max(10, n * 0.3)))
+
+    im = ax.imshow(ordered_corr, cmap="RdBu_r", vmin=-1, vmax=1, aspect="auto")
+    ax.set_xticks(range(n))
+    ax.set_yticks(range(n))
+    ax.set_xticklabels(leaf_labels, rotation=90, fontsize=max(6, min(10, 200 // n)))
+    ax.set_yticklabels(leaf_labels, fontsize=max(6, min(10, 200 // n)))
+    ax.set_title("Feature Correlation Matrix (Clustered)", fontsize=14, pad=20)
+
+    cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+    cbar.set_label("Correlation", rotation=270, labelpad=20, fontsize=12)
+
+    fig.tight_layout()
+    plt.savefig(save_path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Correlation heatmap saved to {save_path}")
+
+
+def suggest_exclusions(clusters, corr_matrix):
+    """
+    For each cluster with more than one feature, suggest dropping the most
+    redundant feature (highest average absolute correlation to other members).
+
+    Parameters
+    ----------
+    clusters : dict
+        Feature clusters mapping cluster_id -> list of feature names.
+    corr_matrix : pd.DataFrame
+        Correlation matrix with feature names as index/columns.
+
+    Returns
+    -------
+    dict
+        Dictionary mapping cluster IDs to suggestion dicts:
+        {"drop": feature_name, "keep": [other_features],
+         "drop_avg_correlation": float, "keep_avg_correlations": [floats]}
+    """
+    suggestions = {}
+
+    for cluster_id, features in clusters.items():
+        if len(features) <= 1:
+            continue
+
+        avg_corrs = []
+        for f in features:
+            others = [o for o in features if o != f]
+            if f in corr_matrix.index and all(o in corr_matrix.columns for o in others):
+                avg_corr = float(corr_matrix.loc[f, others].abs().mean())
+            else:
+                avg_corr = 0.0
+            avg_corrs.append(avg_corr)
+
+        max_idx = int(np.argmax(avg_corrs))
+        drop_feature = features[max_idx]
+        keep_features = [f for i, f in enumerate(features) if i != max_idx]
+
+        suggestions[cluster_id] = {
+            "drop": drop_feature,
+            "keep": keep_features,
+            "drop_avg_correlation": avg_corrs[max_idx],
+            "keep_avg_correlations": [
+                avg_corrs[i] for i in range(len(features)) if i != max_idx
+            ],
+        }
+
+    logger.info(
+        f"Generated exclusion suggestions for {len(suggestions)} multi-feature clusters"
+    )
+    return suggestions
+
+
+def save_analysis_outputs(corr_matrix, cluster_result, out_dir):
+    """
+    Save all analysis artifacts to the output directory.
+
+    Parameters
+    ----------
+    corr_matrix : pd.DataFrame
+        Correlation matrix.
+    cluster_result : dict
+        Output from compute_feature_clusters.
+    out_dir : str or Path
+        Output directory.
+
+    Returns
+    -------
+    dict
+        Paths to the saved files.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    paths = {}
+    n_features = len(corr_matrix.columns)
+    logger.info(f"Saving analysis outputs ({n_features} features) to {out_dir}...")
+
+    # Save correlation matrix CSV
+    csv_path = out_dir / "correlation_matrix.csv"
+    corr_matrix.to_csv(csv_path)
+    paths["correlation_matrix"] = str(csv_path)
+    logger.info(f"  [1/4] Correlation matrix CSV saved to {csv_path}")
+
+    # Save feature clusters JSON
+    clusters_path = out_dir / "feature_clusters.json"
+    with open(clusters_path, "w") as f:
+        json.dump(cluster_result["clusters"], f, indent=2)
+    paths["feature_clusters"] = str(clusters_path)
+    logger.info(f"  [2/4] Feature clusters JSON saved to {clusters_path}")
+
+    # Save dendrogram PNG
+    dendro_path = out_dir / "dendrogram.png"
+    logger.info("  [3/4] Rendering dendrogram...")
+    plot_dendrogram(corr_matrix, cluster_result["linkage"], dendro_path)
+    paths["dendrogram"] = str(dendro_path)
+
+    # Save heatmap PNG
+    heatmap_path = out_dir / "correlation_heatmap.png"
+    logger.info("  [4/4] Rendering correlation heatmap...")
+    plot_correlation_heatmap(corr_matrix, cluster_result["dendrogram"], heatmap_path)
+    paths["correlation_heatmap"] = str(heatmap_path)
+
+    return paths

--- a/reVeal/feature_analysis.py
+++ b/reVeal/feature_analysis.py
@@ -15,7 +15,7 @@ from scipy.cluster import hierarchy
 from scipy.spatial.distance import squareform
 from scipy.stats import spearmanr
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def compute_correlation_matrix(X, columns, method="spearman"):
@@ -51,12 +51,12 @@ def compute_correlation_matrix(X, columns, method="spearman"):
             "Cannot compute a correlation matrix."
         )
     if n_features == 1:
-        logger.info("Only 1 non-constant feature; returning trivial 1x1 correlation matrix.")
+        LOGGER.info("Only 1 non-constant feature; returning trivial 1x1 correlation matrix.")
         return pd.DataFrame(
             [[1.0]], index=df.columns.tolist(), columns=df.columns.tolist()
         )
 
-    logger.info(
+    LOGGER.info(
         f"Computing {method} correlation matrix for {n_features} features "
         f"across {n_samples:,} samples... (this may take a few minutes for large grids)"
     )
@@ -71,7 +71,7 @@ def compute_correlation_matrix(X, columns, method="spearman"):
     else:
         raise ValueError(f"Unknown correlation method: {method}. Use 'spearman' or 'pearson'.")
 
-    logger.info("Correlation matrix computed. Post-processing...")
+    LOGGER.info("Correlation matrix computed. Post-processing...")
 
     # Handle NaN and ensure symmetry
     corr = np.nan_to_num(corr, nan=0.0)
@@ -104,7 +104,7 @@ def compute_feature_clusters(corr_matrix, threshold=0.7):
     corr = corr_matrix.values
     features = corr_matrix.columns.tolist()
 
-    logger.info(f"Computing hierarchical clustering for {len(features)} features...")
+    LOGGER.info(f"Computing hierarchical clustering for {len(features)} features...")
 
     # Convert correlation to distance
     distance_matrix = 1 - np.abs(corr)
@@ -124,7 +124,7 @@ def compute_feature_clusters(corr_matrix, threshold=0.7):
             feature_clusters[cluster_key] = []
         feature_clusters[cluster_key].append(features[idx])
 
-    logger.info(f"Identified {len(feature_clusters)} feature clusters at threshold={threshold}")
+    LOGGER.info(f"Identified {len(feature_clusters)} feature clusters at threshold={threshold}")
 
     # Generate dendrogram data (without plotting)
     dendro = hierarchy.dendrogram(dist_linkage, labels=features, no_plot=True)
@@ -170,7 +170,7 @@ def plot_dendrogram(corr_matrix, linkage, save_path):
     fig.tight_layout()
     plt.savefig(save_path, dpi=300, bbox_inches="tight")
     plt.close(fig)
-    logger.info(f"Dendrogram saved to {save_path}")
+    LOGGER.info(f"Dendrogram saved to {save_path}")
 
 
 def plot_correlation_heatmap(corr_matrix, dendro_result, save_path):
@@ -213,7 +213,7 @@ def plot_correlation_heatmap(corr_matrix, dendro_result, save_path):
     fig.tight_layout()
     plt.savefig(save_path, dpi=300, bbox_inches="tight")
     plt.close(fig)
-    logger.info(f"Correlation heatmap saved to {save_path}")
+    LOGGER.info(f"Correlation heatmap saved to {save_path}")
 
 
 def suggest_exclusions(clusters, corr_matrix):
@@ -263,7 +263,7 @@ def suggest_exclusions(clusters, corr_matrix):
             ],
         }
 
-    logger.info(
+    LOGGER.info(
         f"Generated exclusion suggestions for {len(suggestions)} multi-feature clusters"
     )
     return suggestions
@@ -292,30 +292,30 @@ def save_analysis_outputs(corr_matrix, cluster_result, out_dir):
 
     paths = {}
     n_features = len(corr_matrix.columns)
-    logger.info(f"Saving analysis outputs ({n_features} features) to {out_dir}...")
+    LOGGER.info(f"Saving analysis outputs ({n_features} features) to {out_dir}...")
 
     # Save correlation matrix CSV
     csv_path = out_dir / "correlation_matrix.csv"
     corr_matrix.to_csv(csv_path)
     paths["correlation_matrix"] = str(csv_path)
-    logger.info(f"  [1/4] Correlation matrix CSV saved to {csv_path}")
+    LOGGER.info(f"  [1/4] Correlation matrix CSV saved to {csv_path}")
 
     # Save feature clusters JSON
     clusters_path = out_dir / "feature_clusters.json"
     with open(clusters_path, "w") as f:
         json.dump(cluster_result["clusters"], f, indent=2)
     paths["feature_clusters"] = str(clusters_path)
-    logger.info(f"  [2/4] Feature clusters JSON saved to {clusters_path}")
+    LOGGER.info(f"  [2/4] Feature clusters JSON saved to {clusters_path}")
 
     # Save dendrogram PNG
     dendro_path = out_dir / "dendrogram.png"
-    logger.info("  [3/4] Rendering dendrogram...")
+    LOGGER.info("  [3/4] Rendering dendrogram...")
     plot_dendrogram(corr_matrix, cluster_result["linkage"], dendro_path)
     paths["dendrogram"] = str(dendro_path)
 
     # Save heatmap PNG
     heatmap_path = out_dir / "correlation_heatmap.png"
-    logger.info("  [4/4] Rendering correlation heatmap...")
+    LOGGER.info("  [4/4] Rendering correlation heatmap...")
     plot_correlation_heatmap(corr_matrix, cluster_result["dendrogram"], heatmap_path)
     paths["correlation_heatmap"] = str(heatmap_path)
 

--- a/reVeal/learn_weights.py
+++ b/reVeal/learn_weights.py
@@ -400,7 +400,7 @@ def generate_score_weighted_config(weights, grid_path, score_name="suitability_s
     }
 
 
-def run_learn_weights(config):
+def run_learn_weights(config, progress_callback=None):
     """
     Full pipeline: read data, train PU model, output weight config.
 
@@ -408,20 +408,33 @@ def run_learn_weights(config):
     ----------
     config : LearnWeightsConfig
         Validated configuration object.
+    progress_callback : callable, optional
+        Function that accepts a string message for progress reporting to stdout.
 
     Returns
     -------
     dict
-        Dictionary with keys: 'config' (score_weighted config dict),
-        'metrics' (model evaluation metrics), 'model' (trained PUExtraTrees).
+        Dictionary containing:
+
+        - 'config': score_weighted config dict.
+        - 'metrics': model evaluation metrics dict.
+        - 'model': trained ``PUExtraTrees`` instance.
+        - 'tuning': dict with tuning results (``best_class_prior``,
+          ``best_value``), or ``None`` if tuning was not performed.
     """
+    def _progress(msg):
+        logger.info(msg)
+        if progress_callback:
+            progress_callback(msg)
+
     # Read grid
-    logger.info(f"Reading grid from {config.grid}...")
+    _progress(f"Reading grid from {config.grid}...")
     grid_df = gpd.read_file(config.grid, engine="pyogrio", use_arrow=True)
     grid_df.fillna(0, inplace=True)
+    _progress(f"Grid loaded: {len(grid_df):,} cells, {len(grid_df.columns)} columns.")
 
     # Read labels
-    logger.info(f"Reading labels from {config.labels}...")
+    _progress(f"Reading labels from {config.labels}...")
     labels_gdf = gpd.read_file(config.labels, engine="pyogrio", use_arrow=True)
 
     # Ensure matching CRS
@@ -431,8 +444,17 @@ def run_learn_weights(config):
         labels_gdf = labels_gdf.to_crs(grid_crs)
 
     # Resolve attributes
-    attributes = config.attributes
-    if attributes is None:
+    if config.attributes is not None:
+        attributes = config.attributes
+    elif config.exclude_attributes is not None:
+        all_score_cols = [c for c in grid_df.columns if c.endswith("_score")]
+        exclude_set = set(config.exclude_attributes)
+        attributes = [c for c in all_score_cols if c not in exclude_set]
+        logger.info(
+            f"Excluded {len(exclude_set)} attributes, "
+            f"using {len(attributes)} of {len(all_score_cols)} score columns."
+        )
+    else:
         attributes = [c for c in grid_df.columns if c.endswith("_score")]
         logger.info(f"Auto-detected {len(attributes)} score attributes.")
 
@@ -454,6 +476,7 @@ def run_learn_weights(config):
         )
 
     # Prepare data
+    _progress("Preparing PU data splits...")
     data_splits = prepare_pu_data(
         grid_df=grid_df,
         labels_gdf=labels_gdf,
@@ -467,6 +490,7 @@ def run_learn_weights(config):
     class_prior = config.class_prior
     tuning_results = None
     if config.tune and class_prior is None:
+        _progress(f"Tuning class_prior with Optuna ({config.n_trials} trials)...")
         tuning_results = tune_class_prior(
             grid_df=grid_df,
             data_splits=data_splits,
@@ -478,8 +502,10 @@ def run_learn_weights(config):
             metric=config.tuning_metric,
         )
         class_prior = tuning_results["best_class_prior"]
+        _progress(f"Tuning complete. Best class_prior={class_prior:.4f}")
 
     # Train model
+    _progress(f"Training PUExtraTrees ({config.n_estimators} trees, n_jobs={config.n_jobs})...")
     results = train_pu_model(
         grid_df=grid_df,
         data_splits=data_splits,
@@ -489,6 +515,7 @@ def run_learn_weights(config):
         n_jobs=config.n_jobs,
         random_state=config.random_state,
     )
+    _progress("Training complete.")
 
     # Convert to weights
     weights = importances_to_weights(results["feature_importances"], attributes)

--- a/reVeal/learn_weights.py
+++ b/reVeal/learn_weights.py
@@ -14,7 +14,7 @@ from sklearn.metrics import roc_auc_score
 
 from reVeal.pu import PUExtraTrees
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 optuna.logging.set_verbosity(optuna.logging.WARNING)
 
@@ -65,7 +65,7 @@ def prepare_pu_data(
         ~grid_df["gid"].isin(all_positive_gids)
     ].values
 
-    logger.info(
+    LOGGER.info(
         f"Found {len(all_positive_gids)} positive cells, "
         f"{len(non_intersecting_gids)} non-intersecting cells."
     )
@@ -99,7 +99,7 @@ def prepare_pu_data(
     bg_val_count = min(len(validation_gids), len(remaining_bg))
     background_val_gids = remaining_bg[:bg_val_count]
 
-    logger.info(
+    LOGGER.info(
         f"Splits: train={len(train_gids)}, val={len(validation_gids)}, "
         f"test={len(test_gids)}, bg={len(background_gids)}, "
         f"bg_test={len(background_test_gids)}, bg_val={len(background_val_gids)}"
@@ -161,7 +161,7 @@ def train_pu_model(grid_df, data_splits, attributes, n_estimators=500,
 
     if class_prior is None:
         class_prior = len(p_tr) / (len(p_tr) + len(u_tr))
-        logger.info(f"Auto-computed class_prior: {class_prior:.4f}")
+        LOGGER.info(f"Auto-computed class_prior: {class_prior:.4f}")
 
     if not (0 < class_prior < 1):
         raise ValueError(
@@ -177,9 +177,9 @@ def train_pu_model(grid_df, data_splits, attributes, n_estimators=500,
         n_jobs=n_jobs,
         random_state=random_state,
     )
-    logger.info(f"Training PUExtraTrees with {n_estimators} trees...")
+    LOGGER.info(f"Training PUExtraTrees with {n_estimators} trees...")
     model.fit(P=p_tr, U=u_tr, pi=class_prior)
-    logger.info("Training complete.")
+    LOGGER.info("Training complete.")
 
     # Feature importances
     importances = model.feature_importances()
@@ -202,7 +202,7 @@ def train_pu_model(grid_df, data_splits, attributes, n_estimators=500,
         metrics["auc"] = float(roc_auc_score(y_test, y_score))
         tpr = y_pred[y_test == 1].sum() / y_test.sum()
         metrics["tpr"] = float(tpr)
-        logger.info(f"Test metrics: AUC={metrics['auc']:.4f}, TPR={metrics['tpr']:.4f}")
+        LOGGER.info(f"Test metrics: AUC={metrics['auc']:.4f}, TPR={metrics['tpr']:.4f}")
 
     return {
         "model": model,
@@ -305,7 +305,7 @@ def tune_class_prior(grid_df, data_splits, attributes, n_estimators=500,
     dict
         Dictionary with 'best_class_prior' and 'best_value'.
     """
-    logger.info(
+    LOGGER.info(
         f"Tuning class_prior with {n_trials} trials, optimizing '{metric}'..."
     )
 
@@ -327,7 +327,7 @@ def tune_class_prior(grid_df, data_splits, attributes, n_estimators=500,
 
     best_prior = study.best_params["class_prior"]
     best_value = study.best_value
-    logger.info(
+    LOGGER.info(
         f"Tuning complete. Best class_prior={best_prior:.4f}, "
         f"best {metric}={best_value:.4f}"
     )
@@ -400,7 +400,7 @@ def generate_score_weighted_config(weights, grid_path, score_name="suitability_s
     }
 
 
-def run_learn_weights(config, progress_callback=None):
+def run_learn_weights(config):
     """
     Full pipeline: read data, train PU model, output weight config.
 
@@ -408,8 +408,6 @@ def run_learn_weights(config, progress_callback=None):
     ----------
     config : LearnWeightsConfig
         Validated configuration object.
-    progress_callback : callable, optional
-        Function that accepts a string message for progress reporting to stdout.
 
     Returns
     -------
@@ -422,25 +420,20 @@ def run_learn_weights(config, progress_callback=None):
         - 'tuning': dict with tuning results (``best_class_prior``,
           ``best_value``), or ``None`` if tuning was not performed.
     """
-    def _progress(msg):
-        logger.info(msg)
-        if progress_callback:
-            progress_callback(msg)
-
     # Read grid
-    _progress(f"Reading grid from {config.grid}...")
+    LOGGER.info(f"Reading grid from {config.grid}...")
     grid_df = gpd.read_file(config.grid, engine="pyogrio", use_arrow=True)
     grid_df.fillna(0, inplace=True)
-    _progress(f"Grid loaded: {len(grid_df):,} cells, {len(grid_df.columns)} columns.")
+    LOGGER.info(f"Grid loaded: {len(grid_df):,} cells, {len(grid_df.columns)} columns.")
 
     # Read labels
-    _progress(f"Reading labels from {config.labels}...")
+    LOGGER.info(f"Reading labels from {config.labels}...")
     labels_gdf = gpd.read_file(config.labels, engine="pyogrio", use_arrow=True)
 
     # Ensure matching CRS
     grid_crs = grid_df.crs
     if labels_gdf.crs != grid_crs:
-        logger.info(f"Reprojecting labels to grid CRS ({grid_crs})...")
+        LOGGER.info(f"Reprojecting labels to grid CRS ({grid_crs})...")
         labels_gdf = labels_gdf.to_crs(grid_crs)
 
     # Resolve attributes
@@ -450,13 +443,13 @@ def run_learn_weights(config, progress_callback=None):
         all_score_cols = [c for c in grid_df.columns if c.endswith("_score")]
         exclude_set = set(config.exclude_attributes)
         attributes = [c for c in all_score_cols if c not in exclude_set]
-        logger.info(
+        LOGGER.info(
             f"Excluded {len(exclude_set)} attributes, "
             f"using {len(attributes)} of {len(all_score_cols)} score columns."
         )
     else:
         attributes = [c for c in grid_df.columns if c.endswith("_score")]
-        logger.info(f"Auto-detected {len(attributes)} score attributes.")
+        LOGGER.info(f"Auto-detected {len(attributes)} score attributes.")
 
     if not attributes:
         raise ValueError(
@@ -471,12 +464,12 @@ def run_learn_weights(config, progress_callback=None):
     # Filter to cells with valid developable area if column exists
     if "developable_area_m2_score" in grid_df.columns:
         grid_df = grid_df[grid_df["developable_area_m2_score"] > 0]
-        logger.info(
+        LOGGER.info(
             f"Filtered to {len(grid_df)} cells with developable_area_m2_score > 0."
         )
 
     # Prepare data
-    _progress("Preparing PU data splits...")
+    LOGGER.info("Preparing PU data splits...")
     data_splits = prepare_pu_data(
         grid_df=grid_df,
         labels_gdf=labels_gdf,
@@ -490,7 +483,7 @@ def run_learn_weights(config, progress_callback=None):
     class_prior = config.class_prior
     tuning_results = None
     if config.tune and class_prior is None:
-        _progress(f"Tuning class_prior with Optuna ({config.n_trials} trials)...")
+        LOGGER.info(f"Tuning class_prior with Optuna ({config.n_trials} trials)...")
         tuning_results = tune_class_prior(
             grid_df=grid_df,
             data_splits=data_splits,
@@ -502,10 +495,10 @@ def run_learn_weights(config, progress_callback=None):
             metric=config.tuning_metric,
         )
         class_prior = tuning_results["best_class_prior"]
-        _progress(f"Tuning complete. Best class_prior={class_prior:.4f}")
+        LOGGER.info(f"Tuning complete. Best class_prior={class_prior:.4f}")
 
     # Train model
-    _progress(f"Training PUExtraTrees ({config.n_estimators} trees, n_jobs={config.n_jobs})...")
+    LOGGER.info(f"Training PUExtraTrees ({config.n_estimators} trees, n_jobs={config.n_jobs})...")
     results = train_pu_model(
         grid_df=grid_df,
         data_splits=data_splits,
@@ -515,11 +508,11 @@ def run_learn_weights(config, progress_callback=None):
         n_jobs=config.n_jobs,
         random_state=config.random_state,
     )
-    _progress("Training complete.")
+    LOGGER.info("Training complete.")
 
     # Convert to weights
     weights = importances_to_weights(results["feature_importances"], attributes)
-    logger.info(f"Derived {len(weights)} non-zero weights from {len(attributes)} features.")
+    LOGGER.info(f"Derived {len(weights)} non-zero weights from {len(attributes)} features.")
 
     # Generate output config
     score_config = generate_score_weighted_config(

--- a/tests/test_analyze_features.py
+++ b/tests/test_analyze_features.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for analyze_features CLI and config.
+"""
+import json
+
+import geopandas as gpd
+import numpy as np
+import pytest
+from shapely.geometry import box
+
+from pydantic import ValidationError
+
+from reVeal.config.analyze_features import AnalyzeFeaturesConfig
+
+
+@pytest.fixture
+def synthetic_grid(tmp_path):
+    """Create a synthetic grid with score columns saved as GPKG."""
+    rng = np.random.default_rng(42)
+    n_cells = 200
+
+    geoms = [box(i % 20, i // 20, (i % 20) + 1, (i // 20) + 1) for i in range(n_cells)]
+
+    data = {
+        "gid": list(range(n_cells)),
+        "feature_a_score": rng.uniform(0, 1, n_cells),
+        "feature_b_score": rng.uniform(0, 1, n_cells),
+        "feature_c_score": rng.uniform(0, 1, n_cells),
+        "geometry": geoms,
+    }
+
+    gdf = gpd.GeoDataFrame(data, crs="EPSG:4326")
+    grid_path = tmp_path / "grid.gpkg"
+    gdf.to_file(grid_path, driver="GPKG")
+    return grid_path
+
+
+class TestAnalyzeFeaturesConfig:
+    """Tests for AnalyzeFeaturesConfig validation."""
+
+    def test_valid_config(self, synthetic_grid):
+        """Test creating a valid config."""
+        config = AnalyzeFeaturesConfig(grid=synthetic_grid)
+        assert config.correlation_method == "spearman"
+        assert config.cluster_threshold == 0.7
+
+    def test_pearson_method(self, synthetic_grid):
+        """Test pearson correlation method is accepted."""
+        config = AnalyzeFeaturesConfig(
+            grid=synthetic_grid, correlation_method="pearson"
+        )
+        assert config.correlation_method == "pearson"
+
+    def test_custom_threshold(self, synthetic_grid):
+        """Test custom cluster threshold."""
+        config = AnalyzeFeaturesConfig(
+            grid=synthetic_grid, cluster_threshold=1.5
+        )
+        assert config.cluster_threshold == 1.5
+
+    def test_invalid_threshold_zero(self, synthetic_grid):
+        """Test that threshold=0 is rejected."""
+        with pytest.raises(ValidationError):
+            AnalyzeFeaturesConfig(grid=synthetic_grid, cluster_threshold=0)
+
+    def test_invalid_threshold_over_2(self, synthetic_grid):
+        """Test that threshold > 2 is rejected."""
+        with pytest.raises(ValidationError):
+            AnalyzeFeaturesConfig(grid=synthetic_grid, cluster_threshold=2.5)
+
+    def test_mutual_exclusion_attributes(self, synthetic_grid):
+        """Test that specifying both attribute options raises error."""
+        with pytest.raises(ValidationError, match="Only one of"):
+            AnalyzeFeaturesConfig(
+                grid=synthetic_grid,
+                attributes=["a_score"],
+                exclude_attributes=["b_score"],
+            )
+
+
+class TestAnalyzeFeaturesRun:
+    """Tests for the analyze-features run function."""
+
+    def test_full_analysis_run(self, synthetic_grid, tmp_path):
+        """Test that run() produces expected output files."""
+        from reVeal.cli.analyze_features import run
+
+        out_dir = tmp_path / "output"
+        run(
+            grid=str(synthetic_grid),
+            out_dir=str(out_dir),
+            correlation_method="spearman",
+            cluster_threshold=0.7,
+            _local=False,
+        )
+
+        analysis_dir = out_dir / "analysis"
+        assert analysis_dir.exists()
+        assert (analysis_dir / "correlation_matrix.csv").exists()
+        assert (analysis_dir / "feature_clusters.json").exists()
+        assert (analysis_dir / "dendrogram.png").exists()
+        assert (analysis_dir / "correlation_heatmap.png").exists()
+        assert (analysis_dir / "suggested_exclusions.json").exists()
+
+    def test_explicit_attributes(self, synthetic_grid, tmp_path):
+        """Test that attributes filters features."""
+        from reVeal.cli.analyze_features import run
+
+        out_dir = tmp_path / "output"
+        run(
+            grid=str(synthetic_grid),
+            out_dir=str(out_dir),
+            attributes=["feature_a_score", "feature_b_score"],
+            _local=False,
+        )
+
+        analysis_dir = out_dir / "analysis"
+        # Correlation matrix should only have 2 features
+        import pandas as pd
+        corr = pd.read_csv(analysis_dir / "correlation_matrix.csv", index_col=0)
+        assert len(corr.columns) == 2
+
+    def test_exclude_attributes(self, synthetic_grid, tmp_path):
+        """Test that exclude_attributes filters features."""
+        from reVeal.cli.analyze_features import run
+
+        out_dir = tmp_path / "output"
+        run(
+            grid=str(synthetic_grid),
+            out_dir=str(out_dir),
+            exclude_attributes=["feature_c_score"],
+            _local=False,
+        )
+
+        analysis_dir = out_dir / "analysis"
+        import pandas as pd
+        corr = pd.read_csv(analysis_dir / "correlation_matrix.csv", index_col=0)
+        assert "feature_c_score" not in corr.columns
+
+    def test_pearson_method(self, synthetic_grid, tmp_path):
+        """Test pearson correlation method in run."""
+        from reVeal.cli.analyze_features import run
+
+        out_dir = tmp_path / "output"
+        run(
+            grid=str(synthetic_grid),
+            out_dir=str(out_dir),
+            correlation_method="pearson",
+            _local=False,
+        )
+
+        assert (out_dir / "analysis" / "correlation_matrix.csv").exists()
+
+    def test_no_score_columns_raises(self, tmp_path):
+        """Test that a grid without score columns raises ValueError."""
+        from reVeal.cli.analyze_features import run
+
+        # Create a grid with no _score columns
+        geoms = [box(0, 0, 1, 1), box(1, 0, 2, 1)]
+        gdf = gpd.GeoDataFrame(
+            {"gid": [0, 1], "other_col": [1.0, 2.0], "geometry": geoms},
+            crs="EPSG:4326",
+        )
+        grid_path = tmp_path / "no_scores.gpkg"
+        gdf.to_file(grid_path, driver="GPKG")
+
+        out_dir = tmp_path / "output"
+        with pytest.raises(ValueError, match="No attributes found"):
+            run(grid=str(grid_path), out_dir=str(out_dir), _local=False)
+
+    def test_suggested_exclusions_content(self, synthetic_grid, tmp_path):
+        """Test that suggested_exclusions.json has valid structure."""
+        from reVeal.cli.analyze_features import run
+
+        out_dir = tmp_path / "output"
+        run(
+            grid=str(synthetic_grid),
+            out_dir=str(out_dir),
+            _local=False,
+        )
+
+        exclusions_path = out_dir / "analysis" / "suggested_exclusions.json"
+        with open(exclusions_path) as f:
+            data = json.load(f)
+
+        # Should be a dict (possibly empty if no multi-feature clusters)
+        assert isinstance(data, dict)
+        for cluster_id, suggestion in data.items():
+            assert "drop" in suggestion
+            assert "keep" in suggestion
+            assert isinstance(suggestion["keep"], list)

--- a/tests/test_feature_analysis.py
+++ b/tests/test_feature_analysis.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for feature_analysis module.
+"""
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from reVeal.feature_analysis import (
+    compute_correlation_matrix,
+    compute_feature_clusters,
+    plot_dendrogram,
+    plot_correlation_heatmap,
+    suggest_exclusions,
+    save_analysis_outputs,
+)
+
+
+@pytest.fixture
+def simple_data():
+    """Create simple correlated data for testing."""
+    rng = np.random.default_rng(42)
+    n = 100
+    # a and b are highly correlated; c is independent
+    a = rng.uniform(0, 1, n)
+    b = a + rng.normal(0, 0.05, n)  # strongly correlated with a
+    c = rng.uniform(0, 1, n)  # independent
+    X = np.column_stack([a, b, c])
+    columns = ["feat_a_score", "feat_b_score", "feat_c_score"]
+    return X, columns
+
+
+@pytest.fixture
+def five_feature_data():
+    """Create 5-feature data with known cluster structure."""
+    rng = np.random.default_rng(123)
+    n = 200
+    # Cluster 1: a, b (correlated)
+    a = rng.uniform(0, 1, n)
+    b = a * 0.9 + rng.normal(0, 0.1, n)
+    # Cluster 2: c, d (correlated)
+    c = rng.uniform(0, 1, n)
+    d = c * 0.85 + rng.normal(0, 0.12, n)
+    # Standalone: e
+    e = rng.uniform(0, 1, n)
+    X = np.column_stack([a, b, c, d, e])
+    columns = ["a_score", "b_score", "c_score", "d_score", "e_score"]
+    return X, columns
+
+
+class TestComputeCorrelationMatrix:
+    """Tests for compute_correlation_matrix."""
+
+    def test_spearman_output_shape(self, simple_data):
+        """Test that output is a square DataFrame with correct shape."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        assert isinstance(corr, pd.DataFrame)
+        assert corr.shape == (3, 3)
+        assert list(corr.columns) == columns
+        assert list(corr.index) == columns
+
+    def test_pearson_output_shape(self, simple_data):
+        """Test pearson method also works."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="pearson")
+        assert corr.shape == (3, 3)
+
+    def test_diagonal_is_one(self, simple_data):
+        """Test that diagonal elements are 1.0."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        for i in range(len(columns)):
+            assert abs(corr.iloc[i, i] - 1.0) < 1e-10
+
+    def test_symmetry(self, simple_data):
+        """Test that correlation matrix is symmetric."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        np.testing.assert_allclose(corr.values, corr.values.T, atol=1e-10)
+
+    def test_high_correlation_detected(self, simple_data):
+        """Test that correlated features have high correlation."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        # a and b should be highly correlated
+        assert abs(corr.loc["feat_a_score", "feat_b_score"]) > 0.9
+        # c should be less correlated
+        assert abs(corr.loc["feat_a_score", "feat_c_score"]) < 0.5
+
+    def test_invalid_method_raises(self, simple_data):
+        """Test that invalid method raises ValueError."""
+        X, columns = simple_data
+        with pytest.raises(ValueError, match="Unknown correlation method"):
+            compute_correlation_matrix(X, columns, method="kendall")
+
+    def test_constant_column_dropped(self):
+        """Test that constant columns are dropped."""
+        X = np.array([[1, 2, 5], [1, 3, 6], [1, 4, 7]], dtype=float)
+        columns = ["const", "vary1", "vary2"]
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        assert "const" not in corr.columns
+        assert corr.shape == (2, 2)
+
+
+class TestComputeFeatureClusters:
+    """Tests for compute_feature_clusters."""
+
+    def test_returns_expected_keys(self, simple_data):
+        """Test that output has expected structure."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        result = compute_feature_clusters(corr, threshold=0.7)
+        assert "clusters" in result
+        assert "linkage" in result
+        assert "dendrogram" in result
+
+    def test_correlated_features_cluster_together(self, simple_data):
+        """Test that highly correlated features end up in same cluster."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        result = compute_feature_clusters(corr, threshold=0.7)
+        clusters = result["clusters"]
+
+        # Find which cluster contains feat_a and feat_b
+        a_cluster = None
+        b_cluster = None
+        for cid, features in clusters.items():
+            if "feat_a_score" in features:
+                a_cluster = cid
+            if "feat_b_score" in features:
+                b_cluster = cid
+        assert a_cluster == b_cluster
+
+    def test_all_features_assigned(self, five_feature_data):
+        """Test that all features appear in exactly one cluster."""
+        X, columns = five_feature_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        result = compute_feature_clusters(corr, threshold=0.7)
+        clusters = result["clusters"]
+
+        all_features = []
+        for features in clusters.values():
+            all_features.extend(features)
+        assert sorted(all_features) == sorted(columns)
+
+    def test_low_threshold_more_clusters(self, five_feature_data):
+        """Test that lower threshold produces more clusters."""
+        X, columns = five_feature_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        result_low = compute_feature_clusters(corr, threshold=0.3)
+        result_high = compute_feature_clusters(corr, threshold=1.5)
+        assert len(result_low["clusters"]) >= len(result_high["clusters"])
+
+
+class TestPlotDendrogram:
+    """Tests for plot_dendrogram."""
+
+    def test_creates_file(self, simple_data, tmp_path):
+        """Test that a PNG file is created."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        result = compute_feature_clusters(corr, threshold=0.7)
+        save_path = tmp_path / "dendro.png"
+        plot_dendrogram(corr, result["linkage"], save_path)
+        assert save_path.exists()
+        assert save_path.stat().st_size > 0
+
+
+class TestPlotCorrelationHeatmap:
+    """Tests for plot_correlation_heatmap."""
+
+    def test_creates_file(self, simple_data, tmp_path):
+        """Test that a PNG file is created."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        result = compute_feature_clusters(corr, threshold=0.7)
+        save_path = tmp_path / "heatmap.png"
+        plot_correlation_heatmap(corr, result["dendrogram"], save_path)
+        assert save_path.exists()
+        assert save_path.stat().st_size > 0
+
+
+class TestSuggestExclusions:
+    """Tests for suggest_exclusions."""
+
+    def test_suggests_most_redundant(self):
+        """Test that the most redundant feature in a cluster is suggested for drop."""
+        # Build a correlation matrix where b_score is most correlated with others
+        corr_data = np.array([
+            [1.0, 0.9, 0.3],
+            [0.9, 1.0, 0.8],
+            [0.3, 0.8, 1.0],
+        ])
+        columns = ["a_score", "b_score", "c_score"]
+        corr_matrix = pd.DataFrame(corr_data, index=columns, columns=columns)
+
+        clusters = {
+            "cluster_1": ["a_score", "b_score", "c_score"],
+            "cluster_2": ["d_score"],
+        }
+
+        suggestions = suggest_exclusions(clusters, corr_matrix)
+
+        # Only cluster_1 has >1 feature
+        assert "cluster_1" in suggestions
+        assert "cluster_2" not in suggestions
+        # b_score has highest avg correlation to others: (0.9+0.8)/2=0.85
+        assert suggestions["cluster_1"]["drop"] == "b_score"
+        assert "a_score" in suggestions["cluster_1"]["keep"]
+        assert "c_score" in suggestions["cluster_1"]["keep"]
+
+    def test_empty_clusters_no_suggestions(self):
+        """Test that single-feature clusters produce no suggestions."""
+        corr_data = np.array([[1.0, 0.2], [0.2, 1.0]])
+        columns = ["a_score", "b_score"]
+        corr_matrix = pd.DataFrame(corr_data, index=columns, columns=columns)
+
+        clusters = {
+            "cluster_1": ["a_score"],
+            "cluster_2": ["b_score"],
+        }
+
+        suggestions = suggest_exclusions(clusters, corr_matrix)
+        assert suggestions == {}
+
+    def test_multiple_multi_feature_clusters(self):
+        """Test with multiple clusters needing suggestions."""
+        corr_data = np.array([
+            [1.0, 0.8, 0.1, 0.1],
+            [0.8, 1.0, 0.1, 0.1],
+            [0.1, 0.1, 1.0, 0.7],
+            [0.1, 0.1, 0.7, 1.0],
+        ])
+        columns = ["a_score", "b_score", "c_score", "d_score"]
+        corr_matrix = pd.DataFrame(corr_data, index=columns, columns=columns)
+
+        clusters = {
+            "cluster_1": ["a_score", "b_score"],
+            "cluster_2": ["c_score", "d_score"],
+        }
+
+        suggestions = suggest_exclusions(clusters, corr_matrix)
+        assert len(suggestions) == 2
+        # In 2-feature clusters, both have the same avg corr to the other,
+        # so either could be picked (argmax picks first in ties)
+        assert suggestions["cluster_1"]["drop"] in ["a_score", "b_score"]
+        assert suggestions["cluster_2"]["drop"] in ["c_score", "d_score"]
+
+
+class TestSaveAnalysisOutputs:
+    """Tests for save_analysis_outputs."""
+
+    def test_saves_all_files(self, simple_data, tmp_path):
+        """Test that all expected output files are created."""
+        X, columns = simple_data
+        corr = compute_correlation_matrix(X, columns, method="spearman")
+        cluster_result = compute_feature_clusters(corr, threshold=0.7)
+
+        paths = save_analysis_outputs(corr, cluster_result, tmp_path)
+
+        assert (tmp_path / "correlation_matrix.csv").exists()
+        assert (tmp_path / "feature_clusters.json").exists()
+        assert (tmp_path / "dendrogram.png").exists()
+        assert (tmp_path / "correlation_heatmap.png").exists()
+
+        # Verify JSON is valid
+        with open(tmp_path / "feature_clusters.json") as f:
+            clusters = json.load(f)
+        assert isinstance(clusters, dict)
+
+        # Verify CSV is valid
+        df = pd.read_csv(tmp_path / "correlation_matrix.csv", index_col=0)
+        assert df.shape[0] == df.shape[1]

--- a/tests/test_learn_weights.py
+++ b/tests/test_learn_weights.py
@@ -7,12 +7,16 @@ import geopandas as gpd
 import pytest
 from shapely.geometry import Point, box
 
+from pydantic import ValidationError
+
+from reVeal.config.learn_weights import LearnWeightsConfig
 from reVeal.learn_weights import (
     prepare_pu_data,
     train_pu_model,
     tune_class_prior,
     importances_to_weights,
     generate_score_weighted_config,
+    run_learn_weights,
 )
 
 
@@ -363,3 +367,61 @@ class TestTuneClassPrior:
 
         assert results["model"] is not None
         assert len(results["feature_importances"]) == 3
+
+
+class TestAttributeSelection:
+    """Tests for attributes / exclude_attributes config."""
+
+    def test_explicit_attributes(self, synthetic_grid, synthetic_labels):
+        """Test that explicit attributes limits features to those specified."""
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            background_samples=50,
+            random_state=42,
+        )
+        # Only use 2 of 3 features
+        results = train_pu_model(
+            grid_df=synthetic_grid,
+            data_splits=splits,
+            attributes=["feature_a_score", "feature_b_score"],
+            n_estimators=10,
+            random_state=42,
+        )
+        assert len(results["feature_importances"]) == 2
+
+    def test_exclude_attributes_removes(self, synthetic_grid, synthetic_labels):
+        """Test that exclude removes specified features from auto-detected set."""
+        all_score_cols = [c for c in synthetic_grid.columns if c.endswith("_score")]
+        exclude = ["feature_c_score"]
+        expected = [c for c in all_score_cols if c not in exclude]
+
+        splits = prepare_pu_data(
+            grid_df=synthetic_grid,
+            labels_gdf=synthetic_labels,
+            background_samples=50,
+            random_state=42,
+        )
+        results = train_pu_model(
+            grid_df=synthetic_grid,
+            data_splits=splits,
+            attributes=expected,
+            n_estimators=10,
+            random_state=42,
+        )
+        assert len(results["feature_importances"]) == len(expected)
+
+    def test_mutual_exclusion_attributes_and_exclude(self, synthetic_grid, synthetic_labels, tmp_path):
+        """Test that setting both attributes and exclude_attributes raises."""
+        grid_path = tmp_path / "grid.gpkg"
+        synthetic_grid.to_file(grid_path, driver="GPKG")
+        labels_path = tmp_path / "labels.gpkg"
+        synthetic_labels.to_file(labels_path, driver="GPKG")
+
+        with pytest.raises(ValidationError, match="Only one of"):
+            LearnWeightsConfig(
+                grid=grid_path,
+                labels=labels_path,
+                attributes=["a_score"],
+                exclude_attributes=["b_score"],
+            )


### PR DESCRIPTION
The learn_weights CLI tool derives weights for all data layers given a grid and label set. This is a problem because some data layers might be highly correlated or the user might want to manually exclude data layers given priors. This CLI tool allows the user to iteratively analyze and exclude fields from before it goes into the learn_weights procedure.

Changes:
    - Add `analyze-features` CLI command for computing feature correlation
      analysis (Spearman/Pearson), hierarchical clustering (Ward's linkage),
      and generating exclusion suggestions on normalized grids
    - Add reVeal/feature_analysis.py module with correlation matrix, cluster
      computation, dendrogram/heatmap plotting, and redundancy detection
    - Add  configurable attribute selection (explicit list or exclude-based
      filtering) for `learn_weights` CLI.
    - Output analysis/ subdirectory with correlation_matrix.csv,
      feature_clusters.json, dendrogram.png, correlation_heatmap.png,
      and suggested_exclusions.json
    - Add matplotlib dependency to pyproject.toml and environment.yml
    - Add CLI docs for learn-weights and analyze-features
    - Add tests for feature_analysis (17 tests) and analyze_features (12 tests)
    
Example Correlation Map:
<img width="6054" height="5186" alt="correlation_heatmap" src="https://github.com/user-attachments/assets/f8a72582-c676-4f28-bb2e-209bdf2b2a69" />

Example Dendrogram:
<img width="6931" height="2369" alt="dendrogram" src="https://github.com/user-attachments/assets/e2b2ba57-8a63-4b7d-b90e-719971a98790" />