### PR TITLE
Output learned attributes file from learn-weights and support filepath in score-weighted config

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -2761,7 +2761,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-profiling-1.8.1-pyhd8ed1ab_0.conda
@@ -3198,7 +3198,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-profiling-1.8.1-pyhd8ed1ab_0.conda
@@ -3627,7 +3627,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-profiling-1.8.1-pyhd8ed1ab_0.conda
@@ -4029,7 +4029,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-profiling-1.8.1-pyhd8ed1ab_0.conda
@@ -5819,7 +5819,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-profiling-1.8.1-pyhd8ed1ab_0.conda
@@ -6159,7 +6159,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-profiling-1.8.1-pyhd8ed1ab_0.conda
@@ -6491,7 +6491,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-profiling-1.8.1-pyhd8ed1ab_0.conda
@@ -6797,7 +6797,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-profiling-1.8.1-pyhd8ed1ab_0.conda
@@ -17034,8 +17034,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: nlr-reveal
-  version: 0.2.4.dev17+g4c5ace714.d20260528
-  sha256: 67f2f8780ec785d0dc69719d558eeef872ef428a89c5ba138be2e79d02bab7c6
+  version: 0.2.4.dev21+g3789dd8e3.d20260615
+  sha256: 77de491023094556077c40907c3e78419fb912ed450225ce70cc9738fdae4023
   requires_dist:
   - exactextract>=0.3.0,<0.4
   - geopandas>=1.1.1,<2
@@ -17060,7 +17060,6 @@ packages:
   - ruff-lsp>=0.0.62,<0.0.63 ; extra == 'dev'
   - flaky>=3.8.1,<4 ; extra == 'test'
   - pytest>=9.0.1,<10 ; extra == 'test'
-  - pytest-cases>=3.9.1,<4 ; extra == 'test'
   - pytest-cov>=7.0.0,<8 ; extra == 'test'
   - pytest-mock>=3.15.1,<4 ; extra == 'test'
   - pytest-profiling>=1.8.1,<2 ; extra == 'test'
@@ -19270,20 +19269,20 @@ packages:
   - pkg:pypi/pytest?source=hash-mapping
   size: 299581
   timestamp: 1765062031645
-- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.9.1-pyhd8ed1ab_0.conda
-  sha256: 926c5eab4aa526c9baba6dba62445fa506ae3c865148dcd74d6e00bdb6848bcc
-  md5: 16a55d900e8fd94c149510bca8296181
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
+  sha256: 1b685d7bb59585807ef612cfc4d1be6a082326b1a1d445a0de893f3d2aa20c3d
+  md5: 315adb19d68b8a050f8f330cb8adfc24
   depends:
   - decopatch >=1.4.8
   - makefun >=1.9.5
   - pytest >=2
-  - python >=3.9
+  - python >=3.10
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/pytest-cases?source=hash-mapping
-  size: 88561
-  timestamp: 1749541521100
+  size: 89697
+  timestamp: 1773089022843
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
   sha256: d0f45586aad48ef604590188c33c83d76e4fc6370ac569ba0900906b24fd6a26
   md5: 6891acad5e136cb62a8c2ed2679d6528

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dev = [
 test = [
   "flaky>=3.8.1,<4",
   "pytest>=9.0.1,<10",
-  "pytest-cases>=3.9.1,<4",
   "pytest-cov>=7.0.0,<8",
   "pytest-mock>=3.15.1,<4",
   "pytest-profiling>=1.8.1,<2",
@@ -143,7 +142,7 @@ ruff = ">=0.14.5,<0.15"
 [tool.pixi.feature.test.dependencies]
 flaky = ">=3.8.1,<4"
 pytest = ">=9.0.1,<10"
-pytest-cases = ">=3.9.1,<4"
+pytest-cases = ">=3.10.1,<4"
 pytest-cov = ">=7.0.0,<8"
 pytest-mock = ">=3.15.1,<4"
 pytest-profiling = ">=1.8.1,<2"

--- a/reVeal/cli/learn_weights.py
+++ b/reVeal/cli/learn_weights.py
@@ -103,7 +103,7 @@ def run(
 
     Trains a PUExtraTrees model on a normalized grid using point labels as positive
     samples and auto-sampled background cells as unlabeled samples. Outputs a
-    score-weighted configuration JSON with feature importances normalized as weights
+    learned attributes JSON with feature importances normalized as weights
     (summing to 1.0).
 
     Parameters
@@ -116,7 +116,7 @@ def run(
         positive sample locations. These represent known sites (e.g., data center
         locations).
     out_dir : str
-        Output directory. Results will be saved as ``config_score_weighted.json``
+        Output directory. Results will be saved as ``learned_attributes.json``
         and ``learn_weights_metrics.json``.
     attributes : list of str, optional
         List of column names from the grid to use as features. If not specified,
@@ -187,11 +187,11 @@ def run(
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
 
-    # Save score-weighted config
-    config_out = out_path / "config_score_weighted.json"
-    LOGGER.info(f"Saving score-weighted config to {config_out}")
-    with open(config_out, "w") as f:
-        json.dump(results["config"], f, indent=2)
+    # Save learned attributes
+    attrs_out = out_path / "learned_attributes.json"
+    LOGGER.info(f"Saving learned attributes to {attrs_out}")
+    with open(attrs_out, "w") as f:
+        json.dump(results["attributes"], f, indent=2)
 
     # Save metrics
     if results["metrics"]:

--- a/reVeal/config/score_weighted.py
+++ b/reVeal/config/score_weighted.py
@@ -1,9 +1,11 @@
 """
 config.score_composite module
 """
-from typing import List
+import json
+from typing import List, Union
 import warnings
 from math import isclose
+from pathlib import Path
 
 from typing_extensions import Annotated
 from pydantic import model_validator, FilePath, Field
@@ -54,7 +56,7 @@ class BaseScoreWeightedConfig(BaseGridConfig):
     # pylint: disable=too-few-public-methods
 
     # Input at instantiation
-    attributes: List
+    attributes: Union[FilePath, List]
     score_name: str
 
 
@@ -69,7 +71,8 @@ class ScoreWeightedConfig(BaseScoreWeightedConfig):
     @model_validator(mode="before")
     def propagate_grid(self):
         """
-        Propagate the top level grid parameter down to elements of
+        Validate base types, load attributes from file if a filepath is given,
+        then propagate the top level grid parameter down to elements of
         attributes before validation.
 
         Returns
@@ -77,26 +80,25 @@ class ScoreWeightedConfig(BaseScoreWeightedConfig):
         self
             Returns self.
         """
+        validated = BaseScoreWeightedConfig(**self)
+        self["grid"] = str(validated.grid)
+        attrs = validated.attributes
+        if isinstance(attrs, Path):
+            try:
+                with open(attrs, "r", encoding="utf-8") as f:
+                    self["attributes"] = json.load(f)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Attributes file is not valid JSON: {attrs}"
+                ) from exc
+            if not isinstance(self["attributes"], list):
+                raise ValueError(
+                    f"Attributes file must contain a JSON list: {attrs}"
+                )
 
         for attribute in self["attributes"]:
             if "dset_src" not in attribute:
                 attribute["dset_src"] = self["grid"]
-
-        return self
-
-    @model_validator(mode="before")
-    def base_validator(self):
-        """
-        Ensures that the base validation is run on input data types before
-        other "before"-mode model validators.
-
-        Returns
-        -------
-        self
-            Returns self.
-        """
-
-        BaseScoreWeightedConfig(**self)
 
         return self
 

--- a/reVeal/feature_analysis.py
+++ b/reVeal/feature_analysis.py
@@ -231,9 +231,9 @@ def suggest_exclusions(clusters, corr_matrix):
     Returns
     -------
     dict
-        Dictionary mapping cluster IDs to suggestion dicts:
-        {"drop": feature_name, "keep": [other_features],
-         "drop_avg_correlation": float, "keep_avg_correlations": [floats]}
+        Dictionary mapping cluster IDs to suggestion dicts with keys:
+        ``drop`` (feature_name), ``keep`` (list of other features),
+        ``drop_avg_correlation`` (float), ``keep_avg_correlations`` (list of floats).
     """
     suggestions = {}
 

--- a/reVeal/learn_weights.py
+++ b/reVeal/learn_weights.py
@@ -414,7 +414,7 @@ def run_learn_weights(config):
     dict
         Dictionary containing:
 
-        - 'config': score_weighted config dict.
+        - 'attributes': list of dicts with 'attribute' and 'weight' keys.
         - 'metrics': model evaluation metrics dict.
         - 'model': trained ``PUExtraTrees`` instance.
         - 'tuning': dict with tuning results (``best_class_prior``,
@@ -514,15 +514,8 @@ def run_learn_weights(config):
     weights = importances_to_weights(results["feature_importances"], attributes)
     LOGGER.info(f"Derived {len(weights)} non-zero weights from {len(attributes)} features.")
 
-    # Generate output config
-    score_config = generate_score_weighted_config(
-        weights=weights,
-        grid_path=str(config.grid),
-        score_name=config.score_name,
-    )
-
     return {
-        "config": score_config,
+        "attributes": weights,
         "metrics": results["metrics"],
         "model": results["model"],
         "tuning": tuning_results,

--- a/tests/config/test_learn_weights_config.py
+++ b/tests/config/test_learn_weights_config.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""
+config.learn_weights module tests
+"""
+import numpy as np
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point, box
+
+from pydantic import ValidationError
+
+from reVeal.config.learn_weights import LearnWeightsConfig
+
+
+@pytest.fixture
+def grid_and_labels(tmp_path):
+    """Create a synthetic grid and labels saved as GPKG files."""
+    rng = np.random.default_rng(42)
+    n_cells = 50
+
+    geoms = [box(i % 10, i // 10, (i % 10) + 1, (i // 10) + 1) for i in range(n_cells)]
+    data = {
+        "gid": list(range(n_cells)),
+        "feature_a_score": rng.uniform(0, 1, n_cells),
+        "feature_b_score": rng.uniform(0, 1, n_cells),
+        "geometry": geoms,
+    }
+    gdf = gpd.GeoDataFrame(data, crs="EPSG:4326")
+    grid_path = tmp_path / "grid.gpkg"
+    gdf.to_file(grid_path, driver="GPKG")
+
+    points = [Point(0.5, 0.5), Point(1.5, 0.5), Point(2.5, 0.5)]
+    labels = gpd.GeoDataFrame({"id": [0, 1, 2], "geometry": points}, crs="EPSG:4326")
+    labels_path = tmp_path / "labels.gpkg"
+    labels.to_file(labels_path, driver="GPKG")
+
+    return grid_path, labels_path
+
+
+class TestLearnWeightsConfigValid:
+    """Tests for valid LearnWeightsConfig creation."""
+
+    def test_minimal_config(self, grid_and_labels):
+        """Test creating config with only required fields."""
+        grid_path, labels_path = grid_and_labels
+        config = LearnWeightsConfig(grid=grid_path, labels=labels_path)
+        assert config.n_estimators == 500
+        assert config.attributes is None
+        assert config.exclude_attributes is None
+        assert config.tune is False
+
+    def test_with_attributes(self, grid_and_labels):
+        """Test config with explicit attributes."""
+        grid_path, labels_path = grid_and_labels
+        config = LearnWeightsConfig(
+            grid=grid_path,
+            labels=labels_path,
+            attributes=["feature_a_score", "feature_b_score"],
+        )
+        assert config.attributes == ["feature_a_score", "feature_b_score"]
+
+    def test_with_exclude_attributes(self, grid_and_labels):
+        """Test config with exclude_attributes."""
+        grid_path, labels_path = grid_and_labels
+        config = LearnWeightsConfig(
+            grid=grid_path,
+            labels=labels_path,
+            exclude_attributes=["feature_b_score"],
+        )
+        assert config.exclude_attributes == ["feature_b_score"]
+
+    def test_custom_parameters(self, grid_and_labels):
+        """Test config with custom model parameters."""
+        grid_path, labels_path = grid_and_labels
+        config = LearnWeightsConfig(
+            grid=grid_path,
+            labels=labels_path,
+            n_estimators=100,
+            class_prior=0.3,
+            background_samples=500,
+            test_size=0.3,
+            n_jobs=4,
+            random_state=123,
+            tune=True,
+            n_trials=50,
+            tuning_metric="tpr",
+        )
+        assert config.n_estimators == 100
+        assert config.class_prior == 0.3
+        assert config.background_samples == 500
+        assert config.test_size == 0.3
+        assert config.n_jobs == 4
+        assert config.random_state == 123
+        assert config.tune is True
+        assert config.n_trials == 50
+        assert config.tuning_metric == "tpr"
+
+
+class TestLearnWeightsConfigInvalid:
+    """Tests for invalid LearnWeightsConfig inputs."""
+
+    def test_nonexistent_grid(self, tmp_path):
+        """Test that a nonexistent grid raises ValidationError."""
+        labels_path = tmp_path / "labels.gpkg"
+        gpd.GeoDataFrame(
+            {"id": [0], "geometry": [Point(0, 0)]}, crs="EPSG:4326"
+        ).to_file(labels_path, driver="GPKG")
+
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=tmp_path / "no_such_grid.gpkg",
+                labels=labels_path,
+            )
+
+    def test_nonexistent_labels(self, grid_and_labels):
+        """Test that a nonexistent labels file raises ValidationError."""
+        grid_path, _ = grid_and_labels
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path,
+                labels="/no/such/labels.gpkg",
+            )
+
+    def test_mutual_exclusion(self, grid_and_labels):
+        """Test that both attributes and exclude_attributes raises."""
+        grid_path, labels_path = grid_and_labels
+        with pytest.raises(ValidationError, match="Only one of"):
+            LearnWeightsConfig(
+                grid=grid_path,
+                labels=labels_path,
+                attributes=["a_score"],
+                exclude_attributes=["b_score"],
+            )
+
+    def test_n_estimators_too_low(self, grid_and_labels):
+        """Test that n_estimators < 10 raises."""
+        grid_path, labels_path = grid_and_labels
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, n_estimators=5
+            )
+
+    def test_n_estimators_too_high(self, grid_and_labels):
+        """Test that n_estimators > 10000 raises."""
+        grid_path, labels_path = grid_and_labels
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, n_estimators=20000
+            )
+
+    def test_class_prior_out_of_range(self, grid_and_labels):
+        """Test that class_prior outside (0,1) raises."""
+        grid_path, labels_path = grid_and_labels
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, class_prior=0.0
+            )
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, class_prior=1.0
+            )
+
+    def test_test_size_out_of_range(self, grid_and_labels):
+        """Test that test_size outside (0,1) raises."""
+        grid_path, labels_path = grid_and_labels
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, test_size=0.0
+            )
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, test_size=1.0
+            )
+
+    def test_background_samples_too_low(self, grid_and_labels):
+        """Test that background_samples < 100 raises."""
+        grid_path, labels_path = grid_and_labels
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, background_samples=50
+            )
+
+    def test_invalid_tuning_metric(self, grid_and_labels):
+        """Test that invalid tuning_metric raises."""
+        grid_path, labels_path = grid_and_labels
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, tuning_metric="f1"
+            )
+
+    def test_n_trials_too_low(self, grid_and_labels):
+        """Test that n_trials < 1 raises."""
+        grid_path, labels_path = grid_and_labels
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, n_trials=0
+            )
+
+    def test_n_jobs_too_low(self, grid_and_labels):
+        """Test that n_jobs < 1 raises."""
+        grid_path, labels_path = grid_and_labels
+        with pytest.raises(ValidationError):
+            LearnWeightsConfig(
+                grid=grid_path, labels=labels_path, n_jobs=0
+            )

--- a/tests/config/test_score_weighted.py
+++ b/tests/config/test_score_weighted.py
@@ -2,6 +2,8 @@
 """
 config.score_weighted module tests
 """
+import json
+
 import pytest
 
 import geopandas as gpd
@@ -112,6 +114,77 @@ def test_scoreattributesconfig_valid_inputs(data_dir):
     # check dynamic attributes are set
     assert config.grid_ext is not None, "grid_ext not set"
     assert config.grid_flavor is not None, "grid_flavor not set"
+
+
+def test_scoreattributesconfig_from_file(data_dir, tmp_path):
+    """
+    Test that ScoreWeightedConfig accepts a filepath string for attributes.
+    """
+    grid = data_dir / "normalize" / "outputs" / "grid_normalized.gpkg"
+    attributes = [
+        {"attribute": "generator_mwh_score", "weight": 0.25},
+        {"attribute": "tline_length_score", "weight": 0.25},
+        {"attribute": "fttp_average_speed_score", "weight": 0.25},
+        {"attribute": "developable_area_score", "weight": 0.25},
+    ]
+    attrs_file = tmp_path / "learned_attributes.json"
+    with open(attrs_file, "w") as f:
+        json.dump(attributes, f)
+
+    config_data = {
+        "grid": grid,
+        "attributes": str(attrs_file),
+        "score_name": "composite_score",
+    }
+    config = ScoreWeightedConfig(**config_data)
+    assert len(config.attributes) == 4
+    assert config.attributes[0].attribute == "generator_mwh_score"
+
+
+def test_scoreattributesconfig_from_file_nonexistent(data_dir):
+    """
+    Test that ScoreWeightedConfig raises ValidationError for non-existent filepath.
+    """
+    grid = data_dir / "normalize" / "outputs" / "grid_normalized.gpkg"
+    config_data = {
+        "grid": grid,
+        "attributes": "/nonexistent/path/to/attributes.json",
+        "score_name": "composite_score",
+    }
+    with pytest.raises(ValidationError):
+        ScoreWeightedConfig(**config_data)
+
+
+def test_scoreattributesconfig_from_file_invalid_json(data_dir, tmp_path):
+    """
+    Test that ScoreWeightedConfig raises ValidationError for invalid JSON file.
+    """
+    grid = data_dir / "normalize" / "outputs" / "grid_normalized.gpkg"
+    attrs_file = tmp_path / "bad.json"
+    attrs_file.write_text("not valid json {{{")
+    config_data = {
+        "grid": grid,
+        "attributes": str(attrs_file),
+        "score_name": "composite_score",
+    }
+    with pytest.raises(ValidationError, match="not valid JSON"):
+        ScoreWeightedConfig(**config_data)
+
+
+def test_scoreattributesconfig_from_file_not_a_list(data_dir, tmp_path):
+    """
+    Test that ScoreWeightedConfig raises ValidationError when file contains a dict.
+    """
+    grid = data_dir / "normalize" / "outputs" / "grid_normalized.gpkg"
+    attrs_file = tmp_path / "dict.json"
+    attrs_file.write_text('{"key": "value"}')
+    config_data = {
+        "grid": grid,
+        "attributes": str(attrs_file),
+        "score_name": "composite_score",
+    }
+    with pytest.raises(ValidationError, match="must contain a JSON list"):
+        ScoreWeightedConfig(**config_data)
 
 
 def test_scoreweightedconfig_nonexistent_grid():


### PR DESCRIPTION
learn-weights CLI now outputs learned_attributes.json (list of attribute/weight dicts) instead of a full. config_score_weighted.json. ScoreWeightedConfig accepts attributes as either a list or a string filepath.

This was tested through pytest as well as individual runs of learn_weights and score_weighted. I ran the full pipeline: characterize -> normalize -> learn -> score -> downscale. The results are currently in /home/ichristi/reVeal but will move it to /projects/largeload/geospatial/runs/test_scenarios when this goes in